### PR TITLE
Update funciton get_frame_information

### DIFF
--- a/better_exceptions/__init__.py
+++ b/better_exceptions/__init__.py
@@ -138,9 +138,11 @@ def get_relevant_values(source, frame, tree):
 
 
 def get_frame_information(frame):
-    function = inspect.getframeinfo(frame)[2]
-    filename = inspect.getsourcefile(frame)
-    lineno = frame.f_lineno
+    
+    frame_info = inspect.getframeinfo(frame)
+    filename = frame_info.filename
+    lineno = frame_info.lineno
+    function = frame_info.function
     source = linecache.getline(filename, lineno).strip()
 
     try:


### PR DESCRIPTION
We could use `inspect.getframeinfo()` method to parse all info of a frame that we need. So that this get_frame_information function would be more clear.