### PR TITLE
using relative imports to support sub packaging

### DIFF
--- a/better_exceptions/__init__.py
+++ b/better_exceptions/__init__.py
@@ -24,9 +24,9 @@ import re
 import sys
 import traceback
 
-from better_exceptions.color import STREAM, SUPPORTS_COLOR
-from better_exceptions.log import BetExcLogger, patch as patch_logging
-from better_exceptions.repl import interact, get_repl
+from .color import STREAM, SUPPORTS_COLOR
+from .log import BetExcLogger, patch as patch_logging
+from .repl import interact, get_repl
 
 
 def isast(v):

--- a/better_exceptions/log.py
+++ b/better_exceptions/log.py
@@ -7,7 +7,7 @@ from logging import Logger, StreamHandler
 
 def patch():
     import logging
-    from better_exceptions import format_exception
+    from . import format_exception
 
     logging_format_exception = lambda exc_info: format_exception(*exc_info)
 


### PR DESCRIPTION
This change was required to sub package better_exceptions into another package, so that better_exceptions is not part of the search path.
```
own_package
    __init__.py
    better_exceptions
        __init__.py
        ...
    ...
```