### PR TITLE
Fix Non-ASCII exceptions UnicodeDecodeError 

### DIFF
--- a/test/output/python2-dumb-UTF-8-color.out
+++ b/test/output/python2-dumb-UTF-8-color.out
@@ -26,6 +26,23 @@ True
 
 
 
+python2 test/test_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_encoding.py", line 13, in <module>
+    div()
+    [36m└ <function div at 0xDEADBEEF>[m
+  File "test/test_encoding.py", line 10, in div
+    [33;1mreturn[m _deep([31m'天'[m)
+    [36m       └ <function _deep at 0xDEADBEEF>[m
+  File "test/test_encoding.py", line 7, in _deep
+    [33;1mreturn[m [31m1[m / val
+    [36m           └ '天'[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python2-dumb-UTF-8-nocolor.out
+++ b/test/output/python2-dumb-UTF-8-nocolor.out
@@ -26,6 +26,23 @@ False
 
 
 
+python2 test/test_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_encoding.py", line 13, in <module>
+    div()
+    └ <function div at 0xDEADBEEF>
+  File "test/test_encoding.py", line 10, in div
+    return _deep("天")
+           └ <function _deep at 0xDEADBEEF>
+  File "test/test_encoding.py", line 7, in _deep
+    return 1 / val
+               └ '天'
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python2-dumb-ascii-color.out
+++ b/test/output/python2-dumb-ascii-color.out
@@ -26,6 +26,23 @@ True
 
 
 
+python2 test/test_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_encoding.py", line 13, in <module>
+    div()
+    [36m-> <function div at 0xDEADBEEF>[m
+  File "test/test_encoding.py", line 10, in div
+    [33;1mreturn[m _deep([31m'天'[m)
+    [36m       -> <function _deep at 0xDEADBEEF>[m
+  File "test/test_encoding.py", line 7, in _deep
+    [33;1mreturn[m [31m1[m / val
+    [36m           -> '天'[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python2-dumb-ascii-nocolor.out
+++ b/test/output/python2-dumb-ascii-nocolor.out
@@ -26,6 +26,23 @@ False
 
 
 
+python2 test/test_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_encoding.py", line 13, in <module>
+    div()
+    -> <function div at 0xDEADBEEF>
+  File "test/test_encoding.py", line 10, in div
+    return _deep("天")
+           -> <function _deep at 0xDEADBEEF>
+  File "test/test_encoding.py", line 7, in _deep
+    return 1 / val
+               -> '天'
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python2-vt100-UTF-8-color.out
+++ b/test/output/python2-vt100-UTF-8-color.out
@@ -26,6 +26,23 @@ True
 
 
 
+python2 test/test_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_encoding.py", line 13, in <module>
+    div()
+    [36m└ <function div at 0xDEADBEEF>[m
+  File "test/test_encoding.py", line 10, in div
+    [33;1mreturn[m _deep([31m'天'[m)
+    [36m       └ <function _deep at 0xDEADBEEF>[m
+  File "test/test_encoding.py", line 7, in _deep
+    [33;1mreturn[m [31m1[m / val
+    [36m           └ '天'[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python2-vt100-UTF-8-nocolor.out
+++ b/test/output/python2-vt100-UTF-8-nocolor.out
@@ -26,6 +26,23 @@ False
 
 
 
+python2 test/test_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_encoding.py", line 13, in <module>
+    div()
+    └ <function div at 0xDEADBEEF>
+  File "test/test_encoding.py", line 10, in div
+    return _deep("天")
+           └ <function _deep at 0xDEADBEEF>
+  File "test/test_encoding.py", line 7, in _deep
+    return 1 / val
+               └ '天'
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python2-vt100-ascii-color.out
+++ b/test/output/python2-vt100-ascii-color.out
@@ -26,6 +26,23 @@ True
 
 
 
+python2 test/test_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_encoding.py", line 13, in <module>
+    div()
+    [36m-> <function div at 0xDEADBEEF>[m
+  File "test/test_encoding.py", line 10, in div
+    [33;1mreturn[m _deep([31m'天'[m)
+    [36m       -> <function _deep at 0xDEADBEEF>[m
+  File "test/test_encoding.py", line 7, in _deep
+    [33;1mreturn[m [31m1[m / val
+    [36m           -> '天'[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python2-vt100-ascii-nocolor.out
+++ b/test/output/python2-vt100-ascii-nocolor.out
@@ -26,6 +26,23 @@ False
 
 
 
+python2 test/test_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_encoding.py", line 13, in <module>
+    div()
+    -> <function div at 0xDEADBEEF>
+  File "test/test_encoding.py", line 10, in div
+    return _deep("天")
+           -> <function _deep at 0xDEADBEEF>
+  File "test/test_encoding.py", line 7, in _deep
+    return 1 / val
+               -> '天'
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python2-xterm-UTF-8-color.out
+++ b/test/output/python2-xterm-UTF-8-color.out
@@ -26,6 +26,23 @@ True
 
 
 
+python2 test/test_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_encoding.py", line 13, in <module>
+    div()
+    [36m└ <function div at 0xDEADBEEF>[m
+  File "test/test_encoding.py", line 10, in div
+    [33;1mreturn[m _deep([31m'天'[m)
+    [36m       └ <function _deep at 0xDEADBEEF>[m
+  File "test/test_encoding.py", line 7, in _deep
+    [33;1mreturn[m [31m1[m / val
+    [36m           └ '天'[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python2-xterm-UTF-8-nocolor.out
+++ b/test/output/python2-xterm-UTF-8-nocolor.out
@@ -26,6 +26,23 @@ False
 
 
 
+python2 test/test_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_encoding.py", line 13, in <module>
+    div()
+    └ <function div at 0xDEADBEEF>
+  File "test/test_encoding.py", line 10, in div
+    return _deep("天")
+           └ <function _deep at 0xDEADBEEF>
+  File "test/test_encoding.py", line 7, in _deep
+    return 1 / val
+               └ '天'
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python2-xterm-ascii-color.out
+++ b/test/output/python2-xterm-ascii-color.out
@@ -26,6 +26,23 @@ True
 
 
 
+python2 test/test_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_encoding.py", line 13, in <module>
+    div()
+    [36m-> <function div at 0xDEADBEEF>[m
+  File "test/test_encoding.py", line 10, in div
+    [33;1mreturn[m _deep([31m'天'[m)
+    [36m       -> <function _deep at 0xDEADBEEF>[m
+  File "test/test_encoding.py", line 7, in _deep
+    [33;1mreturn[m [31m1[m / val
+    [36m           -> '天'[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python2-xterm-ascii-nocolor.out
+++ b/test/output/python2-xterm-ascii-nocolor.out
@@ -26,6 +26,23 @@ False
 
 
 
+python2 test/test_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_encoding.py", line 13, in <module>
+    div()
+    -> <function div at 0xDEADBEEF>
+  File "test/test_encoding.py", line 10, in div
+    return _deep("天")
+           -> <function _deep at 0xDEADBEEF>
+  File "test/test_encoding.py", line 7, in _deep
+    return 1 / val
+               -> '天'
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python3-dumb-UTF-8-color.out
+++ b/test/output/python3-dumb-UTF-8-color.out
@@ -26,6 +26,23 @@ True
 
 
 
+python3 test/test_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_encoding.py", line 13, in <module>
+    div()
+    [36m└ <function div at 0xDEADBEEF>[m
+  File "test/test_encoding.py", line 10, in div
+    [33;1mreturn[m _deep([31m'天'[m)
+    [36m       └ <function _deep at 0xDEADBEEF>[m
+  File "test/test_encoding.py", line 7, in _deep
+    [33;1mreturn[m [31m1[m / val
+    [36m           └ '天'[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python3-dumb-UTF-8-nocolor.out
+++ b/test/output/python3-dumb-UTF-8-nocolor.out
@@ -26,6 +26,23 @@ False
 
 
 
+python3 test/test_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_encoding.py", line 13, in <module>
+    div()
+    └ <function div at 0xDEADBEEF>
+  File "test/test_encoding.py", line 10, in div
+    return _deep("天")
+           └ <function _deep at 0xDEADBEEF>
+  File "test/test_encoding.py", line 7, in _deep
+    return 1 / val
+               └ '天'
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python3-dumb-ascii-color.out
+++ b/test/output/python3-dumb-ascii-color.out
@@ -26,6 +26,23 @@ True
 
 
 
+python3 test/test_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_encoding.py", line 13, in <module>
+    div()
+    [36m-> <function div at 0xDEADBEEF>[m
+  File "test/test_encoding.py", line 10, in div
+    [33;1mreturn[m _deep([31m'天'[m)
+    [36m       -> <function _deep at 0xDEADBEEF>[m
+  File "test/test_encoding.py", line 7, in _deep
+    [33;1mreturn[m [31m1[m / val
+    [36m           -> '天'[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python3-dumb-ascii-nocolor.out
+++ b/test/output/python3-dumb-ascii-nocolor.out
@@ -26,6 +26,23 @@ False
 
 
 
+python3 test/test_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_encoding.py", line 13, in <module>
+    div()
+    -> <function div at 0xDEADBEEF>
+  File "test/test_encoding.py", line 10, in div
+    return _deep("天")
+           -> <function _deep at 0xDEADBEEF>
+  File "test/test_encoding.py", line 7, in _deep
+    return 1 / val
+               -> '天'
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python3-vt100-UTF-8-color.out
+++ b/test/output/python3-vt100-UTF-8-color.out
@@ -26,6 +26,23 @@ True
 
 
 
+python3 test/test_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_encoding.py", line 13, in <module>
+    div()
+    [36m└ <function div at 0xDEADBEEF>[m
+  File "test/test_encoding.py", line 10, in div
+    [33;1mreturn[m _deep([31m'天'[m)
+    [36m       └ <function _deep at 0xDEADBEEF>[m
+  File "test/test_encoding.py", line 7, in _deep
+    [33;1mreturn[m [31m1[m / val
+    [36m           └ '天'[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python3-vt100-UTF-8-nocolor.out
+++ b/test/output/python3-vt100-UTF-8-nocolor.out
@@ -26,6 +26,23 @@ False
 
 
 
+python3 test/test_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_encoding.py", line 13, in <module>
+    div()
+    └ <function div at 0xDEADBEEF>
+  File "test/test_encoding.py", line 10, in div
+    return _deep("天")
+           └ <function _deep at 0xDEADBEEF>
+  File "test/test_encoding.py", line 7, in _deep
+    return 1 / val
+               └ '天'
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python3-vt100-ascii-color.out
+++ b/test/output/python3-vt100-ascii-color.out
@@ -26,6 +26,23 @@ True
 
 
 
+python3 test/test_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_encoding.py", line 13, in <module>
+    div()
+    [36m-> <function div at 0xDEADBEEF>[m
+  File "test/test_encoding.py", line 10, in div
+    [33;1mreturn[m _deep([31m'天'[m)
+    [36m       -> <function _deep at 0xDEADBEEF>[m
+  File "test/test_encoding.py", line 7, in _deep
+    [33;1mreturn[m [31m1[m / val
+    [36m           -> '天'[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python3-vt100-ascii-nocolor.out
+++ b/test/output/python3-vt100-ascii-nocolor.out
@@ -26,6 +26,23 @@ False
 
 
 
+python3 test/test_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_encoding.py", line 13, in <module>
+    div()
+    -> <function div at 0xDEADBEEF>
+  File "test/test_encoding.py", line 10, in div
+    return _deep("天")
+           -> <function _deep at 0xDEADBEEF>
+  File "test/test_encoding.py", line 7, in _deep
+    return 1 / val
+               -> '天'
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python3-xterm-UTF-8-color.out
+++ b/test/output/python3-xterm-UTF-8-color.out
@@ -26,6 +26,23 @@ True
 
 
 
+python3 test/test_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_encoding.py", line 13, in <module>
+    div()
+    [36m└ <function div at 0xDEADBEEF>[m
+  File "test/test_encoding.py", line 10, in div
+    [33;1mreturn[m _deep([31m'天'[m)
+    [36m       └ <function _deep at 0xDEADBEEF>[m
+  File "test/test_encoding.py", line 7, in _deep
+    [33;1mreturn[m [31m1[m / val
+    [36m           └ '天'[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python3-xterm-UTF-8-nocolor.out
+++ b/test/output/python3-xterm-UTF-8-nocolor.out
@@ -26,6 +26,23 @@ False
 
 
 
+python3 test/test_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_encoding.py", line 13, in <module>
+    div()
+    └ <function div at 0xDEADBEEF>
+  File "test/test_encoding.py", line 10, in div
+    return _deep("天")
+           └ <function _deep at 0xDEADBEEF>
+  File "test/test_encoding.py", line 7, in _deep
+    return 1 / val
+               └ '天'
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python3-xterm-ascii-color.out
+++ b/test/output/python3-xterm-ascii-color.out
@@ -26,6 +26,23 @@ True
 
 
 
+python3 test/test_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_encoding.py", line 13, in <module>
+    div()
+    [36m-> <function div at 0xDEADBEEF>[m
+  File "test/test_encoding.py", line 10, in div
+    [33;1mreturn[m _deep([31m'天'[m)
+    [36m       -> <function _deep at 0xDEADBEEF>[m
+  File "test/test_encoding.py", line 7, in _deep
+    [33;1mreturn[m [31m1[m / val
+    [36m           -> '天'[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python3-xterm-ascii-nocolor.out
+++ b/test/output/python3-xterm-ascii-nocolor.out
@@ -26,6 +26,23 @@ False
 
 
 
+python3 test/test_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_encoding.py", line 13, in <module>
+    div()
+    -> <function div at 0xDEADBEEF>
+  File "test/test_encoding.py", line 10, in div
+    return _deep("天")
+           -> <function _deep at 0xDEADBEEF>
+  File "test/test_encoding.py", line 7, in _deep
+    return 1 / val
+               -> '天'
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/test_encoding.py
+++ b/test/test_encoding.py
@@ -1,0 +1,13 @@
+# -*- coding:utf-8 -*-
+
+import better_exceptions
+
+
+def _deep(val):
+    return 1 / val
+
+def div():
+    return _deep("天")
+
+
+div()

--- a/test_all.sh
+++ b/test_all.sh
@@ -34,6 +34,7 @@ function test_case {
 function test_all {
 	test_case "$BETEXC_PYTHON" "test/test.py"
 	test_case "$BETEXC_PYTHON" "test/test_color.py"
+	test_case "$BETEXC_PYTHON" "test/test_encoding.py"
 	test_case "./test/test_interactive.sh"
 	# test_case "./test/test_interactive_raw.sh"
 	test_case "./test/test_string.sh"


### PR DESCRIPTION
Fix Traceback includes Non-ASCII characters will cause `UnicodeDecodeError`.

Here is the test code:

```python
# -*- coding:utf-8 -*-

import better_exceptions


def _deep(val):
    return 1 / val

def div():
    return _deep("天")


div()
```