### PR TITLE
Fix long Non-ASCII characters decode with "string-escape" error

### DIFF
--- a/better_exceptions/__init__.py
+++ b/better_exceptions/__init__.py
@@ -279,7 +279,12 @@ def format_traceback_frame(tb):
         if not PY3 and isinstance(val, str):
             # In Python2 the Non-ASCII value will be the escaped string,
             # use string-escape to decode the string to show the text in human way.
-            val = _unicode(val.decode("string-escape"))
+            # If string is very long, the val will only contians part of the string,
+            # that will cause decode error, so we just decode the complete string
+            # which ends with quote.
+            if val.endswith(val[0]):
+                val = val.decode("string-escape")
+            val = _unicode(val)
 
         line += u'{}{} {}'.format((' ' * (col - index)), CAP_CHAR, val)
         lines.append(THEME['inspect'](line))

--- a/test/output/python2-dumb-UTF-8-color.out
+++ b/test/output/python2-dumb-UTF-8-color.out
@@ -43,6 +43,23 @@ TypeError: unsupported operand type(s) for /: 'int' and 'str'
 
 
 
+python2 test/test_long_text_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_long_text_encoding.py", line 13, in <module>
+    div()
+    [36m└ <function div at 0xDEADBEEF>[m
+  File "test/test_long_text_encoding.py", line 10, in div
+    [33;1mreturn[m _deep([31m'天'[m * [31m1000[m)
+    [36m       └ <function _deep at 0xDEADBEEF>[m
+  File "test/test_long_text_encoding.py", line 7, in _deep
+    [33;1mreturn[m [31m1[m / val
+    [36m           └ '\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa...[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python2-dumb-UTF-8-nocolor.out
+++ b/test/output/python2-dumb-UTF-8-nocolor.out
@@ -43,6 +43,23 @@ TypeError: unsupported operand type(s) for /: 'int' and 'str'
 
 
 
+python2 test/test_long_text_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_long_text_encoding.py", line 13, in <module>
+    div()
+    └ <function div at 0xDEADBEEF>
+  File "test/test_long_text_encoding.py", line 10, in div
+    return _deep("天" * 1000)
+           └ <function _deep at 0xDEADBEEF>
+  File "test/test_long_text_encoding.py", line 7, in _deep
+    return 1 / val
+               └ '\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa...
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python2-dumb-ascii-color.out
+++ b/test/output/python2-dumb-ascii-color.out
@@ -43,6 +43,23 @@ TypeError: unsupported operand type(s) for /: 'int' and 'str'
 
 
 
+python2 test/test_long_text_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_long_text_encoding.py", line 13, in <module>
+    div()
+    [36m-> <function div at 0xDEADBEEF>[m
+  File "test/test_long_text_encoding.py", line 10, in div
+    [33;1mreturn[m _deep([31m'天'[m * [31m1000[m)
+    [36m       -> <function _deep at 0xDEADBEEF>[m
+  File "test/test_long_text_encoding.py", line 7, in _deep
+    [33;1mreturn[m [31m1[m / val
+    [36m           -> '\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa...[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python2-dumb-ascii-nocolor.out
+++ b/test/output/python2-dumb-ascii-nocolor.out
@@ -43,6 +43,23 @@ TypeError: unsupported operand type(s) for /: 'int' and 'str'
 
 
 
+python2 test/test_long_text_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_long_text_encoding.py", line 13, in <module>
+    div()
+    -> <function div at 0xDEADBEEF>
+  File "test/test_long_text_encoding.py", line 10, in div
+    return _deep("天" * 1000)
+           -> <function _deep at 0xDEADBEEF>
+  File "test/test_long_text_encoding.py", line 7, in _deep
+    return 1 / val
+               -> '\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa...
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python2-vt100-UTF-8-color.out
+++ b/test/output/python2-vt100-UTF-8-color.out
@@ -43,6 +43,23 @@ TypeError: unsupported operand type(s) for /: 'int' and 'str'
 
 
 
+python2 test/test_long_text_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_long_text_encoding.py", line 13, in <module>
+    div()
+    [36m└ <function div at 0xDEADBEEF>[m
+  File "test/test_long_text_encoding.py", line 10, in div
+    [33;1mreturn[m _deep([31m'天'[m * [31m1000[m)
+    [36m       └ <function _deep at 0xDEADBEEF>[m
+  File "test/test_long_text_encoding.py", line 7, in _deep
+    [33;1mreturn[m [31m1[m / val
+    [36m           └ '\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa...[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python2-vt100-UTF-8-nocolor.out
+++ b/test/output/python2-vt100-UTF-8-nocolor.out
@@ -43,6 +43,23 @@ TypeError: unsupported operand type(s) for /: 'int' and 'str'
 
 
 
+python2 test/test_long_text_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_long_text_encoding.py", line 13, in <module>
+    div()
+    └ <function div at 0xDEADBEEF>
+  File "test/test_long_text_encoding.py", line 10, in div
+    return _deep("天" * 1000)
+           └ <function _deep at 0xDEADBEEF>
+  File "test/test_long_text_encoding.py", line 7, in _deep
+    return 1 / val
+               └ '\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa...
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python2-vt100-ascii-color.out
+++ b/test/output/python2-vt100-ascii-color.out
@@ -43,6 +43,23 @@ TypeError: unsupported operand type(s) for /: 'int' and 'str'
 
 
 
+python2 test/test_long_text_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_long_text_encoding.py", line 13, in <module>
+    div()
+    [36m-> <function div at 0xDEADBEEF>[m
+  File "test/test_long_text_encoding.py", line 10, in div
+    [33;1mreturn[m _deep([31m'天'[m * [31m1000[m)
+    [36m       -> <function _deep at 0xDEADBEEF>[m
+  File "test/test_long_text_encoding.py", line 7, in _deep
+    [33;1mreturn[m [31m1[m / val
+    [36m           -> '\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa...[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python2-vt100-ascii-nocolor.out
+++ b/test/output/python2-vt100-ascii-nocolor.out
@@ -43,6 +43,23 @@ TypeError: unsupported operand type(s) for /: 'int' and 'str'
 
 
 
+python2 test/test_long_text_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_long_text_encoding.py", line 13, in <module>
+    div()
+    -> <function div at 0xDEADBEEF>
+  File "test/test_long_text_encoding.py", line 10, in div
+    return _deep("天" * 1000)
+           -> <function _deep at 0xDEADBEEF>
+  File "test/test_long_text_encoding.py", line 7, in _deep
+    return 1 / val
+               -> '\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa...
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python2-xterm-UTF-8-color.out
+++ b/test/output/python2-xterm-UTF-8-color.out
@@ -43,6 +43,23 @@ TypeError: unsupported operand type(s) for /: 'int' and 'str'
 
 
 
+python2 test/test_long_text_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_long_text_encoding.py", line 13, in <module>
+    div()
+    [36m└ <function div at 0xDEADBEEF>[m
+  File "test/test_long_text_encoding.py", line 10, in div
+    [33;1mreturn[m _deep([31m'天'[m * [31m1000[m)
+    [36m       └ <function _deep at 0xDEADBEEF>[m
+  File "test/test_long_text_encoding.py", line 7, in _deep
+    [33;1mreturn[m [31m1[m / val
+    [36m           └ '\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa...[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python2-xterm-UTF-8-nocolor.out
+++ b/test/output/python2-xterm-UTF-8-nocolor.out
@@ -43,6 +43,23 @@ TypeError: unsupported operand type(s) for /: 'int' and 'str'
 
 
 
+python2 test/test_long_text_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_long_text_encoding.py", line 13, in <module>
+    div()
+    └ <function div at 0xDEADBEEF>
+  File "test/test_long_text_encoding.py", line 10, in div
+    return _deep("天" * 1000)
+           └ <function _deep at 0xDEADBEEF>
+  File "test/test_long_text_encoding.py", line 7, in _deep
+    return 1 / val
+               └ '\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa...
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python2-xterm-ascii-color.out
+++ b/test/output/python2-xterm-ascii-color.out
@@ -43,6 +43,23 @@ TypeError: unsupported operand type(s) for /: 'int' and 'str'
 
 
 
+python2 test/test_long_text_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_long_text_encoding.py", line 13, in <module>
+    div()
+    [36m-> <function div at 0xDEADBEEF>[m
+  File "test/test_long_text_encoding.py", line 10, in div
+    [33;1mreturn[m _deep([31m'天'[m * [31m1000[m)
+    [36m       -> <function _deep at 0xDEADBEEF>[m
+  File "test/test_long_text_encoding.py", line 7, in _deep
+    [33;1mreturn[m [31m1[m / val
+    [36m           -> '\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa...[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python2-xterm-ascii-nocolor.out
+++ b/test/output/python2-xterm-ascii-nocolor.out
@@ -43,6 +43,23 @@ TypeError: unsupported operand type(s) for /: 'int' and 'str'
 
 
 
+python2 test/test_long_text_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_long_text_encoding.py", line 13, in <module>
+    div()
+    -> <function div at 0xDEADBEEF>
+  File "test/test_long_text_encoding.py", line 10, in div
+    return _deep("天" * 1000)
+           -> <function _deep at 0xDEADBEEF>
+  File "test/test_long_text_encoding.py", line 7, in _deep
+    return 1 / val
+               -> '\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa4\xa9\xe5\xa...
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python3-dumb-UTF-8-color.out
+++ b/test/output/python3-dumb-UTF-8-color.out
@@ -43,6 +43,23 @@ TypeError: unsupported operand type(s) for /: 'int' and 'str'
 
 
 
+python3 test/test_long_text_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_long_text_encoding.py", line 13, in <module>
+    div()
+    [36m└ <function div at 0xDEADBEEF>[m
+  File "test/test_long_text_encoding.py", line 10, in div
+    [33;1mreturn[m _deep([31m'天'[m * 10[31m1000[m
+    [36m       └ <function _deep at 0xDEADBEEF>[m
+  File "test/test_long_text_encoding.py", line 7, in _deep
+    [33;1mreturn[m [31m1[m / val
+    [36m           └ '天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天...[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python3-dumb-UTF-8-nocolor.out
+++ b/test/output/python3-dumb-UTF-8-nocolor.out
@@ -43,6 +43,23 @@ TypeError: unsupported operand type(s) for /: 'int' and 'str'
 
 
 
+python3 test/test_long_text_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_long_text_encoding.py", line 13, in <module>
+    div()
+    └ <function div at 0xDEADBEEF>
+  File "test/test_long_text_encoding.py", line 10, in div
+    return _deep("天" * 1000)
+           └ <function _deep at 0xDEADBEEF>
+  File "test/test_long_text_encoding.py", line 7, in _deep
+    return 1 / val
+               └ '天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天...
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python3-dumb-ascii-color.out
+++ b/test/output/python3-dumb-ascii-color.out
@@ -43,6 +43,23 @@ TypeError: unsupported operand type(s) for /: 'int' and 'str'
 
 
 
+python3 test/test_long_text_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_long_text_encoding.py", line 13, in <module>
+    div()
+    [36m-> <function div at 0xDEADBEEF>[m
+  File "test/test_long_text_encoding.py", line 10, in div
+    [33;1mreturn[m _deep([31m'天'[m * 10[31m1000[m
+    [36m       -> <function _deep at 0xDEADBEEF>[m
+  File "test/test_long_text_encoding.py", line 7, in _deep
+    [33;1mreturn[m [31m1[m / val
+    [36m           -> '天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天...[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python3-dumb-ascii-nocolor.out
+++ b/test/output/python3-dumb-ascii-nocolor.out
@@ -43,6 +43,23 @@ TypeError: unsupported operand type(s) for /: 'int' and 'str'
 
 
 
+python3 test/test_long_text_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_long_text_encoding.py", line 13, in <module>
+    div()
+    -> <function div at 0xDEADBEEF>
+  File "test/test_long_text_encoding.py", line 10, in div
+    return _deep("天" * 1000)
+           -> <function _deep at 0xDEADBEEF>
+  File "test/test_long_text_encoding.py", line 7, in _deep
+    return 1 / val
+               -> '天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天...
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python3-vt100-UTF-8-color.out
+++ b/test/output/python3-vt100-UTF-8-color.out
@@ -43,6 +43,23 @@ TypeError: unsupported operand type(s) for /: 'int' and 'str'
 
 
 
+python3 test/test_long_text_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_long_text_encoding.py", line 13, in <module>
+    div()
+    [36m└ <function div at 0xDEADBEEF>[m
+  File "test/test_long_text_encoding.py", line 10, in div
+    [33;1mreturn[m _deep([31m'天'[m * 10[31m1000[m
+    [36m       └ <function _deep at 0xDEADBEEF>[m
+  File "test/test_long_text_encoding.py", line 7, in _deep
+    [33;1mreturn[m [31m1[m / val
+    [36m           └ '天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天...[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python3-vt100-UTF-8-nocolor.out
+++ b/test/output/python3-vt100-UTF-8-nocolor.out
@@ -43,6 +43,23 @@ TypeError: unsupported operand type(s) for /: 'int' and 'str'
 
 
 
+python3 test/test_long_text_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_long_text_encoding.py", line 13, in <module>
+    div()
+    └ <function div at 0xDEADBEEF>
+  File "test/test_long_text_encoding.py", line 10, in div
+    return _deep("天" * 1000)
+           └ <function _deep at 0xDEADBEEF>
+  File "test/test_long_text_encoding.py", line 7, in _deep
+    return 1 / val
+               └ '天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天...
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python3-vt100-ascii-color.out
+++ b/test/output/python3-vt100-ascii-color.out
@@ -43,6 +43,23 @@ TypeError: unsupported operand type(s) for /: 'int' and 'str'
 
 
 
+python3 test/test_long_text_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_long_text_encoding.py", line 13, in <module>
+    div()
+    [36m-> <function div at 0xDEADBEEF>[m
+  File "test/test_long_text_encoding.py", line 10, in div
+    [33;1mreturn[m _deep([31m'天'[m * 10[31m1000[m
+    [36m       -> <function _deep at 0xDEADBEEF>[m
+  File "test/test_long_text_encoding.py", line 7, in _deep
+    [33;1mreturn[m [31m1[m / val
+    [36m           -> '天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天...[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python3-vt100-ascii-nocolor.out
+++ b/test/output/python3-vt100-ascii-nocolor.out
@@ -43,6 +43,23 @@ TypeError: unsupported operand type(s) for /: 'int' and 'str'
 
 
 
+python3 test/test_long_text_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_long_text_encoding.py", line 13, in <module>
+    div()
+    -> <function div at 0xDEADBEEF>
+  File "test/test_long_text_encoding.py", line 10, in div
+    return _deep("天" * 1000)
+           -> <function _deep at 0xDEADBEEF>
+  File "test/test_long_text_encoding.py", line 7, in _deep
+    return 1 / val
+               -> '天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天...
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python3-xterm-UTF-8-color.out
+++ b/test/output/python3-xterm-UTF-8-color.out
@@ -43,6 +43,23 @@ TypeError: unsupported operand type(s) for /: 'int' and 'str'
 
 
 
+python3 test/test_long_text_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_long_text_encoding.py", line 13, in <module>
+    div()
+    [36m└ <function div at 0xDEADBEEF>[m
+  File "test/test_long_text_encoding.py", line 10, in div
+    [33;1mreturn[m _deep([31m'天'[m * 10[31m1000[m
+    [36m       └ <function _deep at 0xDEADBEEF>[m
+  File "test/test_long_text_encoding.py", line 7, in _deep
+    [33;1mreturn[m [31m1[m / val
+    [36m           └ '天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天...[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python3-xterm-UTF-8-nocolor.out
+++ b/test/output/python3-xterm-UTF-8-nocolor.out
@@ -43,6 +43,23 @@ TypeError: unsupported operand type(s) for /: 'int' and 'str'
 
 
 
+python3 test/test_long_text_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_long_text_encoding.py", line 13, in <module>
+    div()
+    └ <function div at 0xDEADBEEF>
+  File "test/test_long_text_encoding.py", line 10, in div
+    return _deep("天" * 1000)
+           └ <function _deep at 0xDEADBEEF>
+  File "test/test_long_text_encoding.py", line 7, in _deep
+    return 1 / val
+               └ '天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天...
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python3-xterm-ascii-color.out
+++ b/test/output/python3-xterm-ascii-color.out
@@ -43,6 +43,23 @@ TypeError: unsupported operand type(s) for /: 'int' and 'str'
 
 
 
+python3 test/test_long_text_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_long_text_encoding.py", line 13, in <module>
+    div()
+    [36m-> <function div at 0xDEADBEEF>[m
+  File "test/test_long_text_encoding.py", line 10, in div
+    [33;1mreturn[m _deep([31m'天'[m * 10[31m1000[m
+    [36m       -> <function _deep at 0xDEADBEEF>[m
+  File "test/test_long_text_encoding.py", line 7, in _deep
+    [33;1mreturn[m [31m1[m / val
+    [36m           -> '天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天...[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/output/python3-xterm-ascii-nocolor.out
+++ b/test/output/python3-xterm-ascii-nocolor.out
@@ -43,6 +43,23 @@ TypeError: unsupported operand type(s) for /: 'int' and 'str'
 
 
 
+python3 test/test_long_text_encoding.py
+
+
+Traceback (most recent call last):
+  File "test/test_long_text_encoding.py", line 13, in <module>
+    div()
+    -> <function div at 0xDEADBEEF>
+  File "test/test_long_text_encoding.py", line 10, in div
+    return _deep("天" * 1000)
+           -> <function _deep at 0xDEADBEEF>
+  File "test/test_long_text_encoding.py", line 7, in _deep
+    return 1 / val
+               -> '天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天天...
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
 ./test/test_interactive.sh
 
 

--- a/test/test_long_text_encoding.py
+++ b/test/test_long_text_encoding.py
@@ -1,0 +1,13 @@
+# -*- coding:utf-8 -*-
+
+import better_exceptions
+
+
+def _deep(val):
+    return 1 / val
+
+def div():
+    return _deep("天" * 1000)
+
+
+div()

--- a/test_all.sh
+++ b/test_all.sh
@@ -35,6 +35,7 @@ function test_all {
 	test_case "$BETEXC_PYTHON" "test/test.py"
 	test_case "$BETEXC_PYTHON" "test/test_color.py"
 	test_case "$BETEXC_PYTHON" "test/test_encoding.py"
+	test_case "$BETEXC_PYTHON" "test/test_long_text_encoding.py"
 	test_case "./test/test_interactive.sh"
 	# test_case "./test/test_interactive_raw.sh"
 	test_case "./test/test_string.sh"


### PR DESCRIPTION
Use `string-escape` to decode string will cause error if the string is very long, because the string only contains part of the complete string.