### PR TITLE
Fix SyntaxError missing exception part.

### DIFF
--- a/better_exceptions/__init__.py
+++ b/better_exceptions/__init__.py
@@ -334,7 +334,7 @@ def format_exception(exc, value, tb):
         value.args = (colored_source,)
     title = traceback.format_exception_only(exc, value)
 
-    full_trace = u'Traceback (most recent call last):\n{}{}\n'.format(formatted, title[0].strip())
+    full_trace = u'Traceback (most recent call last):\n{}{}\n'.format(formatted, ''.join(title))
 
     return full_trace
 


### PR DESCRIPTION
`title` contains multiple lines in case of a SyntaxError ([ref](https://docs.python.org/3/library/traceback.html#traceback.format_exception_only)), we want to print them all.