### PR TITLE
Fix raw codes appearing with Python 3 on Windows cmd

### DIFF
--- a/better_exceptions/context.py
+++ b/better_exceptions/context.py
@@ -1,0 +1,3 @@
+import sys
+
+PY3 = sys.version_info[0] >= 3

--- a/better_exceptions/encoding.py
+++ b/better_exceptions/encoding.py
@@ -1,0 +1,32 @@
+import codecs
+import locale
+import sys
+
+from .context import PY3
+
+
+ENCODING = locale.getpreferredencoding()
+
+
+def to_byte(val):
+    unicode_type = str if PY3 else unicode
+    if isinstance(val, unicode_type):
+        try:
+            return val.encode(ENCODING)
+        except UnicodeEncodeError:
+            if PY3:
+                return codecs.escape_decode(val)[0]
+            else:
+                return val.encode("unicode-escape").decode("string-escape")
+
+    return val
+
+
+def to_unicode(val):
+    if isinstance(val, bytes):
+        try:
+            return val.decode(ENCODING)
+        except UnicodeDecodeError:
+            return val.decode("unicode-escape")
+
+    return val


### PR DESCRIPTION
Hi again.

I think I successfully fixed #23.

Before:
![1504551439-screenshot](https://user-images.githubusercontent.com/4193924/30036479-08f8c960-91b4-11e7-9ded-fff488d33487.png)

After:
![1504551475-screenshot](https://user-images.githubusercontent.com/4193924/30036487-0e7f91de-91b4-11e7-909f-86118f220674.png)

----------------

So, the issue was about raw code appearing on Windows with Python 3.

The first problem comes from the fact that Colorama does not wrap `.buffer` so calling `STREAM.buffer.write(data)` was absolutely ineffective on Windows.
The second problem is that string is encoded before being sent, and Colorama does not work with Python 3 bytes strings.
Moreover, it is not possible to just send the non-encoded string as this would result in encoding issues because of the default encoding settings of the stream.

To fix that, I used another wrapper around the `sys.stderr` which is used by Colorama to encode the substrings once win32 calls are made.
Of course, I made this change only for the special case of Python 3 on Windows, stream is untouched for other configurations.

I have not found any other way to solve the problem. Tell me if you have a better idea.