### PR TITLE
Add tests to check correctly truncated values

### DIFF
--- a/test/output/python2-dumb-UTF-8-color.out
+++ b/test/output/python2-dumb-UTF-8-color.out
@@ -148,3 +148,31 @@ AssertionError: [33;1massert[m baz == [31m90[m
 
 
 
+python2 test/test_truncating.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating.py", line 11, in <module>
+    div()
+    [36m└ <function ...[m
+  File "test/test_truncating.py", line 8, in div
+    [33;1mreturn[m [31m1[m / var
+    [36m           └ '999999999...[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
+python2 test/test_truncating_disabled.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating_disabled.py", line 11, in <module>
+    div()
+    [36m└ <function div at 0xDEADBEEF>[m
+  File "test/test_truncating_disabled.py", line 8, in div
+    [33;1mreturn[m [31m1[m / var
+    [36m           └ '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+

--- a/test/output/python2-dumb-UTF-8-nocolor.out
+++ b/test/output/python2-dumb-UTF-8-nocolor.out
@@ -148,3 +148,31 @@ AssertionError: assert baz == 90
 
 
 
+python2 test/test_truncating.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating.py", line 11, in <module>
+    div()
+    └ <function ...
+  File "test/test_truncating.py", line 8, in div
+    return 1 / var
+               └ '999999999...
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
+python2 test/test_truncating_disabled.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating_disabled.py", line 11, in <module>
+    div()
+    └ <function div at 0xDEADBEEF>
+  File "test/test_truncating_disabled.py", line 8, in div
+    return 1 / var
+               └ '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+

--- a/test/output/python2-dumb-ascii-color.out
+++ b/test/output/python2-dumb-ascii-color.out
@@ -148,3 +148,31 @@ AssertionError: [33;1massert[m baz == [31m90[m
 
 
 
+python2 test/test_truncating.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating.py", line 11, in <module>
+    div()
+    [36m-> <function ...[m
+  File "test/test_truncating.py", line 8, in div
+    [33;1mreturn[m [31m1[m / var
+    [36m           -> '999999999...[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
+python2 test/test_truncating_disabled.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating_disabled.py", line 11, in <module>
+    div()
+    [36m-> <function div at 0xDEADBEEF>[m
+  File "test/test_truncating_disabled.py", line 8, in div
+    [33;1mreturn[m [31m1[m / var
+    [36m           -> '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+

--- a/test/output/python2-dumb-ascii-nocolor.out
+++ b/test/output/python2-dumb-ascii-nocolor.out
@@ -148,3 +148,31 @@ AssertionError: assert baz == 90
 
 
 
+python2 test/test_truncating.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating.py", line 11, in <module>
+    div()
+    -> <function ...
+  File "test/test_truncating.py", line 8, in div
+    return 1 / var
+               -> '999999999...
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
+python2 test/test_truncating_disabled.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating_disabled.py", line 11, in <module>
+    div()
+    -> <function div at 0xDEADBEEF>
+  File "test/test_truncating_disabled.py", line 8, in div
+    return 1 / var
+               -> '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+

--- a/test/output/python2-vt100-UTF-8-color.out
+++ b/test/output/python2-vt100-UTF-8-color.out
@@ -148,3 +148,31 @@ AssertionError: [33;1massert[m baz == [31m90[m
 
 
 
+python2 test/test_truncating.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating.py", line 11, in <module>
+    div()
+    [36m└ <function ...[m
+  File "test/test_truncating.py", line 8, in div
+    [33;1mreturn[m [31m1[m / var
+    [36m           └ '999999999...[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
+python2 test/test_truncating_disabled.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating_disabled.py", line 11, in <module>
+    div()
+    [36m└ <function div at 0xDEADBEEF>[m
+  File "test/test_truncating_disabled.py", line 8, in div
+    [33;1mreturn[m [31m1[m / var
+    [36m           └ '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+

--- a/test/output/python2-vt100-UTF-8-nocolor.out
+++ b/test/output/python2-vt100-UTF-8-nocolor.out
@@ -148,3 +148,31 @@ AssertionError: assert baz == 90
 
 
 
+python2 test/test_truncating.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating.py", line 11, in <module>
+    div()
+    └ <function ...
+  File "test/test_truncating.py", line 8, in div
+    return 1 / var
+               └ '999999999...
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
+python2 test/test_truncating_disabled.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating_disabled.py", line 11, in <module>
+    div()
+    └ <function div at 0xDEADBEEF>
+  File "test/test_truncating_disabled.py", line 8, in div
+    return 1 / var
+               └ '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+

--- a/test/output/python2-vt100-ascii-color.out
+++ b/test/output/python2-vt100-ascii-color.out
@@ -148,3 +148,31 @@ AssertionError: [33;1massert[m baz == [31m90[m
 
 
 
+python2 test/test_truncating.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating.py", line 11, in <module>
+    div()
+    [36m-> <function ...[m
+  File "test/test_truncating.py", line 8, in div
+    [33;1mreturn[m [31m1[m / var
+    [36m           -> '999999999...[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
+python2 test/test_truncating_disabled.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating_disabled.py", line 11, in <module>
+    div()
+    [36m-> <function div at 0xDEADBEEF>[m
+  File "test/test_truncating_disabled.py", line 8, in div
+    [33;1mreturn[m [31m1[m / var
+    [36m           -> '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+

--- a/test/output/python2-vt100-ascii-nocolor.out
+++ b/test/output/python2-vt100-ascii-nocolor.out
@@ -148,3 +148,31 @@ AssertionError: assert baz == 90
 
 
 
+python2 test/test_truncating.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating.py", line 11, in <module>
+    div()
+    -> <function ...
+  File "test/test_truncating.py", line 8, in div
+    return 1 / var
+               -> '999999999...
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
+python2 test/test_truncating_disabled.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating_disabled.py", line 11, in <module>
+    div()
+    -> <function div at 0xDEADBEEF>
+  File "test/test_truncating_disabled.py", line 8, in div
+    return 1 / var
+               -> '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+

--- a/test/output/python2-xterm-UTF-8-color.out
+++ b/test/output/python2-xterm-UTF-8-color.out
@@ -148,3 +148,31 @@ AssertionError: [33;1massert[m baz == [31m90[m
 
 
 
+python2 test/test_truncating.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating.py", line 11, in <module>
+    div()
+    [36m└ <function ...[m
+  File "test/test_truncating.py", line 8, in div
+    [33;1mreturn[m [31m1[m / var
+    [36m           └ '999999999...[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
+python2 test/test_truncating_disabled.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating_disabled.py", line 11, in <module>
+    div()
+    [36m└ <function div at 0xDEADBEEF>[m
+  File "test/test_truncating_disabled.py", line 8, in div
+    [33;1mreturn[m [31m1[m / var
+    [36m           └ '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+

--- a/test/output/python2-xterm-UTF-8-nocolor.out
+++ b/test/output/python2-xterm-UTF-8-nocolor.out
@@ -148,3 +148,31 @@ AssertionError: assert baz == 90
 
 
 
+python2 test/test_truncating.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating.py", line 11, in <module>
+    div()
+    └ <function ...
+  File "test/test_truncating.py", line 8, in div
+    return 1 / var
+               └ '999999999...
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
+python2 test/test_truncating_disabled.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating_disabled.py", line 11, in <module>
+    div()
+    └ <function div at 0xDEADBEEF>
+  File "test/test_truncating_disabled.py", line 8, in div
+    return 1 / var
+               └ '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+

--- a/test/output/python2-xterm-ascii-color.out
+++ b/test/output/python2-xterm-ascii-color.out
@@ -148,3 +148,31 @@ AssertionError: [33;1massert[m baz == [31m90[m
 
 
 
+python2 test/test_truncating.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating.py", line 11, in <module>
+    div()
+    [36m-> <function ...[m
+  File "test/test_truncating.py", line 8, in div
+    [33;1mreturn[m [31m1[m / var
+    [36m           -> '999999999...[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
+python2 test/test_truncating_disabled.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating_disabled.py", line 11, in <module>
+    div()
+    [36m-> <function div at 0xDEADBEEF>[m
+  File "test/test_truncating_disabled.py", line 8, in div
+    [33;1mreturn[m [31m1[m / var
+    [36m           -> '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+

--- a/test/output/python2-xterm-ascii-nocolor.out
+++ b/test/output/python2-xterm-ascii-nocolor.out
@@ -148,3 +148,31 @@ AssertionError: assert baz == 90
 
 
 
+python2 test/test_truncating.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating.py", line 11, in <module>
+    div()
+    -> <function ...
+  File "test/test_truncating.py", line 8, in div
+    return 1 / var
+               -> '999999999...
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
+python2 test/test_truncating_disabled.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating_disabled.py", line 11, in <module>
+    div()
+    -> <function div at 0xDEADBEEF>
+  File "test/test_truncating_disabled.py", line 8, in div
+    return 1 / var
+               -> '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+

--- a/test/output/python3-dumb-UTF-8-color.out
+++ b/test/output/python3-dumb-UTF-8-color.out
@@ -147,3 +147,31 @@ AssertionError: [33;1massert[m baz == [31m90[m
 
 
 
+python3 test/test_truncating.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating.py", line 11, in <module>
+    div()
+    [36m└ <function ...[m
+  File "test/test_truncating.py", line 8, in div
+    [33;1mreturn[m [31m1[m / var
+    [36m           └ '999999999...[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
+python3 test/test_truncating_disabled.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating_disabled.py", line 11, in <module>
+    div()
+    [36m└ <function div at 0xDEADBEEF>[m
+  File "test/test_truncating_disabled.py", line 8, in div
+    [33;1mreturn[m [31m1[m / var
+    [36m           └ '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+

--- a/test/output/python3-dumb-UTF-8-nocolor.out
+++ b/test/output/python3-dumb-UTF-8-nocolor.out
@@ -147,3 +147,31 @@ AssertionError: assert baz == 90
 
 
 
+python3 test/test_truncating.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating.py", line 11, in <module>
+    div()
+    └ <function ...
+  File "test/test_truncating.py", line 8, in div
+    return 1 / var
+               └ '999999999...
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
+python3 test/test_truncating_disabled.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating_disabled.py", line 11, in <module>
+    div()
+    └ <function div at 0xDEADBEEF>
+  File "test/test_truncating_disabled.py", line 8, in div
+    return 1 / var
+               └ '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+

--- a/test/output/python3-dumb-ascii-color.out
+++ b/test/output/python3-dumb-ascii-color.out
@@ -147,3 +147,31 @@ AssertionError: [33;1massert[m baz == [31m90[m
 
 
 
+python3 test/test_truncating.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating.py", line 11, in <module>
+    div()
+    [36m-> <function ...[m
+  File "test/test_truncating.py", line 8, in div
+    [33;1mreturn[m [31m1[m / var
+    [36m           -> '999999999...[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
+python3 test/test_truncating_disabled.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating_disabled.py", line 11, in <module>
+    div()
+    [36m-> <function div at 0xDEADBEEF>[m
+  File "test/test_truncating_disabled.py", line 8, in div
+    [33;1mreturn[m [31m1[m / var
+    [36m           -> '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+

--- a/test/output/python3-dumb-ascii-nocolor.out
+++ b/test/output/python3-dumb-ascii-nocolor.out
@@ -147,3 +147,31 @@ AssertionError: assert baz == 90
 
 
 
+python3 test/test_truncating.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating.py", line 11, in <module>
+    div()
+    -> <function ...
+  File "test/test_truncating.py", line 8, in div
+    return 1 / var
+               -> '999999999...
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
+python3 test/test_truncating_disabled.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating_disabled.py", line 11, in <module>
+    div()
+    -> <function div at 0xDEADBEEF>
+  File "test/test_truncating_disabled.py", line 8, in div
+    return 1 / var
+               -> '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+

--- a/test/output/python3-vt100-UTF-8-color.out
+++ b/test/output/python3-vt100-UTF-8-color.out
@@ -147,3 +147,31 @@ AssertionError: [33;1massert[m baz == [31m90[m
 
 
 
+python3 test/test_truncating.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating.py", line 11, in <module>
+    div()
+    [36m└ <function ...[m
+  File "test/test_truncating.py", line 8, in div
+    [33;1mreturn[m [31m1[m / var
+    [36m           └ '999999999...[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
+python3 test/test_truncating_disabled.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating_disabled.py", line 11, in <module>
+    div()
+    [36m└ <function div at 0xDEADBEEF>[m
+  File "test/test_truncating_disabled.py", line 8, in div
+    [33;1mreturn[m [31m1[m / var
+    [36m           └ '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+

--- a/test/output/python3-vt100-UTF-8-nocolor.out
+++ b/test/output/python3-vt100-UTF-8-nocolor.out
@@ -147,3 +147,31 @@ AssertionError: assert baz == 90
 
 
 
+python3 test/test_truncating.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating.py", line 11, in <module>
+    div()
+    └ <function ...
+  File "test/test_truncating.py", line 8, in div
+    return 1 / var
+               └ '999999999...
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
+python3 test/test_truncating_disabled.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating_disabled.py", line 11, in <module>
+    div()
+    └ <function div at 0xDEADBEEF>
+  File "test/test_truncating_disabled.py", line 8, in div
+    return 1 / var
+               └ '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+

--- a/test/output/python3-vt100-ascii-color.out
+++ b/test/output/python3-vt100-ascii-color.out
@@ -147,3 +147,31 @@ AssertionError: [33;1massert[m baz == [31m90[m
 
 
 
+python3 test/test_truncating.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating.py", line 11, in <module>
+    div()
+    [36m-> <function ...[m
+  File "test/test_truncating.py", line 8, in div
+    [33;1mreturn[m [31m1[m / var
+    [36m           -> '999999999...[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
+python3 test/test_truncating_disabled.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating_disabled.py", line 11, in <module>
+    div()
+    [36m-> <function div at 0xDEADBEEF>[m
+  File "test/test_truncating_disabled.py", line 8, in div
+    [33;1mreturn[m [31m1[m / var
+    [36m           -> '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+

--- a/test/output/python3-vt100-ascii-nocolor.out
+++ b/test/output/python3-vt100-ascii-nocolor.out
@@ -147,3 +147,31 @@ AssertionError: assert baz == 90
 
 
 
+python3 test/test_truncating.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating.py", line 11, in <module>
+    div()
+    -> <function ...
+  File "test/test_truncating.py", line 8, in div
+    return 1 / var
+               -> '999999999...
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
+python3 test/test_truncating_disabled.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating_disabled.py", line 11, in <module>
+    div()
+    -> <function div at 0xDEADBEEF>
+  File "test/test_truncating_disabled.py", line 8, in div
+    return 1 / var
+               -> '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+

--- a/test/output/python3-xterm-UTF-8-color.out
+++ b/test/output/python3-xterm-UTF-8-color.out
@@ -147,3 +147,31 @@ AssertionError: [33;1massert[m baz == [31m90[m
 
 
 
+python3 test/test_truncating.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating.py", line 11, in <module>
+    div()
+    [36m└ <function ...[m
+  File "test/test_truncating.py", line 8, in div
+    [33;1mreturn[m [31m1[m / var
+    [36m           └ '999999999...[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
+python3 test/test_truncating_disabled.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating_disabled.py", line 11, in <module>
+    div()
+    [36m└ <function div at 0xDEADBEEF>[m
+  File "test/test_truncating_disabled.py", line 8, in div
+    [33;1mreturn[m [31m1[m / var
+    [36m           └ '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+

--- a/test/output/python3-xterm-UTF-8-nocolor.out
+++ b/test/output/python3-xterm-UTF-8-nocolor.out
@@ -147,3 +147,31 @@ AssertionError: assert baz == 90
 
 
 
+python3 test/test_truncating.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating.py", line 11, in <module>
+    div()
+    └ <function ...
+  File "test/test_truncating.py", line 8, in div
+    return 1 / var
+               └ '999999999...
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
+python3 test/test_truncating_disabled.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating_disabled.py", line 11, in <module>
+    div()
+    └ <function div at 0xDEADBEEF>
+  File "test/test_truncating_disabled.py", line 8, in div
+    return 1 / var
+               └ '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+

--- a/test/output/python3-xterm-ascii-color.out
+++ b/test/output/python3-xterm-ascii-color.out
@@ -147,3 +147,31 @@ AssertionError: [33;1massert[m baz == [31m90[m
 
 
 
+python3 test/test_truncating.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating.py", line 11, in <module>
+    div()
+    [36m-> <function ...[m
+  File "test/test_truncating.py", line 8, in div
+    [33;1mreturn[m [31m1[m / var
+    [36m           -> '999999999...[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
+python3 test/test_truncating_disabled.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating_disabled.py", line 11, in <module>
+    div()
+    [36m-> <function div at 0xDEADBEEF>[m
+  File "test/test_truncating_disabled.py", line 8, in div
+    [33;1mreturn[m [31m1[m / var
+    [36m           -> '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'[m
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+

--- a/test/output/python3-xterm-ascii-nocolor.out
+++ b/test/output/python3-xterm-ascii-nocolor.out
@@ -147,3 +147,31 @@ AssertionError: assert baz == 90
 
 
 
+python3 test/test_truncating.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating.py", line 11, in <module>
+    div()
+    -> <function ...
+  File "test/test_truncating.py", line 8, in div
+    return 1 / var
+               -> '999999999...
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+
+python3 test/test_truncating_disabled.py
+
+
+Traceback (most recent call last):
+  File "test/test_truncating_disabled.py", line 11, in <module>
+    div()
+    -> <function div at 0xDEADBEEF>
+  File "test/test_truncating_disabled.py", line 8, in div
+    return 1 / var
+               -> '999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999'
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+
+
+

--- a/test/test_truncating.py
+++ b/test/test_truncating.py
@@ -1,0 +1,11 @@
+# -*- coding:utf-8 -*-
+
+import better_exceptions
+better_exceptions.MAX_LENGTH = 10
+
+def div():
+    var = "9" * 150
+    return 1 / var
+
+
+div()

--- a/test/test_truncating_disabled.py
+++ b/test/test_truncating_disabled.py
@@ -1,0 +1,11 @@
+# -*- coding:utf-8 -*-
+
+import better_exceptions
+better_exceptions.MAX_LENGTH = None
+
+def div():
+    var = "9" * 150
+    return 1 / var
+
+
+div()

--- a/test_all.sh
+++ b/test_all.sh
@@ -39,6 +39,8 @@ function test_all {
 	# test_case "./test/test_interactive_raw.sh"
 	test_case "./test/test_string.sh"
 	test_case "$BETEXC_PYTHON" "test/test_logging.py"
+	test_case "$BETEXC_PYTHON" "test/test_truncating.py"
+	test_case "$BETEXC_PYTHON" "test/test_truncating_disabled.py"
 }
 
 for encoding in ascii "UTF-8"; do


### PR DESCRIPTION
My pull requests #41 is actually silently breaking some functionnalities of `better-exceptions`, like truncating variable values to a custom length by modifying the constant `MAX_LENGTH`.
I added two tests to check that it works correctly.