### PR TITLE
Add __version__ to top level module

### DIFF
--- a/better_exceptions/__init__.py
+++ b/better_exceptions/__init__.py
@@ -30,6 +30,9 @@ from .log import BetExcLogger, patch as patch_logging
 from .repl import interact, get_repl
 
 
+__version__ = '0.1.8'
+
+
 def isast(v):
     return inspect.isclass(v) and issubclass(v, ast.AST)
 

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,19 @@
+import re
 from distutils.core import setup
 
-VERSION = '0.1.8'
+with open('better_exceptions/__init__.py', 'r') as file:
+    version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
+                        file.read(), re.MULTILINE).group(1)
 
 setup(
     name = 'better_exceptions',
     packages = ['better_exceptions'],
-    version = VERSION,
+    version = version,
     description = 'Pretty and helpful exceptions, automatically',
     author = 'Josh Junon',
     author_email = 'josh@junon.me',
     url = 'https://github.com/qix-/better-exceptions',
-    download_url = 'https://github.com/qix-/better-exceptions/archive/{}.tar.gz'.format(VERSION),
+    download_url = 'https://github.com/qix-/better-exceptions/archive/{}.tar.gz'.format(version),
     keywords = ['pretty', 'better', 'exceptions', 'exception', 'error', 'local', 'debug', 'debugging', 'locals'],
     classifiers = [],
     extras_require = {


### PR DESCRIPTION
It is common for Python modules to have a `__version__` attribute.

To avoid duplicating the version between `__init__.py` and `setup.py`, I used a simplified method of the first one described [here](https://packaging.python.org/guides/single-sourcing-package-version/).