### PR TITLE
Fix unit tests failing on Python 3.7

### DIFF
--- a/better_exceptions/__main__.py
+++ b/better_exceptions/__main__.py
@@ -1,6 +1,22 @@
 import argparse
-import imp
 import os
+
+try:
+    import importlib.machinery
+    import importlib.util
+
+    def load_module(name, filepath):
+        loader = importlib.machinery.SourceFileLoader(name, filepath)
+        spec = importlib.util.spec_from_loader(loader.name, loader)
+        mod = importlib.util.module_from_spec(spec)
+        loader.exec_module(mod)
+
+except ImportError:
+    import imp
+
+    def load_module(name, filepath):
+        with open(filepath, 'r') as fd:
+            imp.load_module('a_b', f, path, ('.py', 'U', imp.PY_SOURCE))
 
 from better_exceptions import interact, hook
 hook()
@@ -12,7 +28,6 @@ args = parser.parse_args()
 
 startup_file = os.getenv('PYTHONSTARTUP')
 if not args.no_init and startup_file is not None:
-    with open(startup_file, 'r') as fd:
-        imp.load_module('pystartup', fd, startup_file, ('.py', 'r', imp.PY_SOURCE))
+    load_module('pystartup', startup_file)
 
 interact(args.quiet)

--- a/test_all.sh
+++ b/test_all.sh
@@ -54,6 +54,8 @@ for encoding in ascii "UTF-8"; do
 
 				export LANG="en_US.${encoding}"
 				export LC_ALL="${LANG}"
+				export PYTHONCOERCECLOCALE=0
+				export PYTHONUTF8=0
 				export TERM="${term}"
 				export FORCE_COLOR="${color}"
 				export BETEXC_PYTHON="python${pv}"


### PR DESCRIPTION
Hey @Qix-!

I noticed that the travis build [was failing](https://travis-ci.org/Qix-/better-exceptions/builds/329513603?utm_source=github_status&utm_medium=notification).

This is due to two changes in the last Python 3.7 versions:
* [PEP 540: Forced UTF-8 Runtime Mode](https://docs.python.org/3/whatsnew/3.7.html#pep-540-forced-utf-8-runtime-mode)
* [PEP 565: Show DeprecationWarning in `__main__`](https://docs.python.org/3/whatsnew/3.7.html#pep-565-show-deprecationwarning-in-main)

So, my proposed fixes are respectively:
* Set appropriate environment variables to disable the utf-8 mode by default
* Avoid use of deprecated `imp` module if possible (workaround copy-pasted from [here](https://stackoverflow.com/a/19011259/2291710))

Does is look good to you?