### PR TITLE
Add support for chained exceptions

### DIFF
--- a/test/output/python3-dumb-UTF-8-color.out
+++ b/test/output/python3-dumb-UTF-8-color.out
@@ -209,3 +209,42 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_chaining.py
+
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 11, in cause
+    div(x, y)
+    [36m│   │  └ 0[m
+    [36m│   └ 1[m
+    [36m└ <function div at 0xDEADBEEF>[m
+  File "test/test_chaining.py", line 7, in div
+    x / y
+    [36m│   └ 0[m
+    [36m└ 1[m
+ZeroDivisionError: division by zero
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 17, in context
+    cause(x, y)
+    [36m│     │  └ 0[m
+    [36m│     └ 1[m
+    [36m└ <function cause at 0xDEADBEEF>[m
+  File "test/test_chaining.py", line 13, in cause
+    [33;1mraise[m [35;1mValueError[m([31m'Division error'[m)
+ValueError: Division error
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 21, in <module>
+    context([31m1[m, [31m0[m)
+    [36m└ <function context at 0xDEADBEEF>[m
+  File "test/test_chaining.py", line 19, in context
+    [33;1mraise[m [35;1mValueError[m([31m'Cause error'[m) from e
+ValueError: Cause error
+
+
+

--- a/test/output/python3-dumb-UTF-8-nocolor.out
+++ b/test/output/python3-dumb-UTF-8-nocolor.out
@@ -209,3 +209,42 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_chaining.py
+
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 11, in cause
+    div(x, y)
+    │   │  └ 0
+    │   └ 1
+    └ <function div at 0xDEADBEEF>
+  File "test/test_chaining.py", line 7, in div
+    x / y
+    │   └ 0
+    └ 1
+ZeroDivisionError: division by zero
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 17, in context
+    cause(x, y)
+    │     │  └ 0
+    │     └ 1
+    └ <function cause at 0xDEADBEEF>
+  File "test/test_chaining.py", line 13, in cause
+    raise ValueError("Division error")
+ValueError: Division error
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 21, in <module>
+    context(1, 0)
+    └ <function context at 0xDEADBEEF>
+  File "test/test_chaining.py", line 19, in context
+    raise ValueError("Cause error") from e
+ValueError: Cause error
+
+
+

--- a/test/output/python3-dumb-ascii-color.out
+++ b/test/output/python3-dumb-ascii-color.out
@@ -209,3 +209,42 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_chaining.py
+
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 11, in cause
+    div(x, y)
+    [36m|   |  -> 0[m
+    [36m|   -> 1[m
+    [36m-> <function div at 0xDEADBEEF>[m
+  File "test/test_chaining.py", line 7, in div
+    x / y
+    [36m|   -> 0[m
+    [36m-> 1[m
+ZeroDivisionError: division by zero
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 17, in context
+    cause(x, y)
+    [36m|     |  -> 0[m
+    [36m|     -> 1[m
+    [36m-> <function cause at 0xDEADBEEF>[m
+  File "test/test_chaining.py", line 13, in cause
+    [33;1mraise[m [35;1mValueError[m([31m'Division error'[m)
+ValueError: Division error
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 21, in <module>
+    context([31m1[m, [31m0[m)
+    [36m-> <function context at 0xDEADBEEF>[m
+  File "test/test_chaining.py", line 19, in context
+    [33;1mraise[m [35;1mValueError[m([31m'Cause error'[m) from e
+ValueError: Cause error
+
+
+

--- a/test/output/python3-dumb-ascii-nocolor.out
+++ b/test/output/python3-dumb-ascii-nocolor.out
@@ -209,3 +209,42 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_chaining.py
+
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 11, in cause
+    div(x, y)
+    |   |  -> 0
+    |   -> 1
+    -> <function div at 0xDEADBEEF>
+  File "test/test_chaining.py", line 7, in div
+    x / y
+    |   -> 0
+    -> 1
+ZeroDivisionError: division by zero
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 17, in context
+    cause(x, y)
+    |     |  -> 0
+    |     -> 1
+    -> <function cause at 0xDEADBEEF>
+  File "test/test_chaining.py", line 13, in cause
+    raise ValueError("Division error")
+ValueError: Division error
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 21, in <module>
+    context(1, 0)
+    -> <function context at 0xDEADBEEF>
+  File "test/test_chaining.py", line 19, in context
+    raise ValueError("Cause error") from e
+ValueError: Cause error
+
+
+

--- a/test/output/python3-vt100-UTF-8-color.out
+++ b/test/output/python3-vt100-UTF-8-color.out
@@ -209,3 +209,42 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_chaining.py
+
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 11, in cause
+    div(x, y)
+    [36m│   │  └ 0[m
+    [36m│   └ 1[m
+    [36m└ <function div at 0xDEADBEEF>[m
+  File "test/test_chaining.py", line 7, in div
+    x / y
+    [36m│   └ 0[m
+    [36m└ 1[m
+ZeroDivisionError: division by zero
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 17, in context
+    cause(x, y)
+    [36m│     │  └ 0[m
+    [36m│     └ 1[m
+    [36m└ <function cause at 0xDEADBEEF>[m
+  File "test/test_chaining.py", line 13, in cause
+    [33;1mraise[m [35;1mValueError[m([31m'Division error'[m)
+ValueError: Division error
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 21, in <module>
+    context([31m1[m, [31m0[m)
+    [36m└ <function context at 0xDEADBEEF>[m
+  File "test/test_chaining.py", line 19, in context
+    [33;1mraise[m [35;1mValueError[m([31m'Cause error'[m) from e
+ValueError: Cause error
+
+
+

--- a/test/output/python3-vt100-UTF-8-nocolor.out
+++ b/test/output/python3-vt100-UTF-8-nocolor.out
@@ -209,3 +209,42 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_chaining.py
+
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 11, in cause
+    div(x, y)
+    │   │  └ 0
+    │   └ 1
+    └ <function div at 0xDEADBEEF>
+  File "test/test_chaining.py", line 7, in div
+    x / y
+    │   └ 0
+    └ 1
+ZeroDivisionError: division by zero
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 17, in context
+    cause(x, y)
+    │     │  └ 0
+    │     └ 1
+    └ <function cause at 0xDEADBEEF>
+  File "test/test_chaining.py", line 13, in cause
+    raise ValueError("Division error")
+ValueError: Division error
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 21, in <module>
+    context(1, 0)
+    └ <function context at 0xDEADBEEF>
+  File "test/test_chaining.py", line 19, in context
+    raise ValueError("Cause error") from e
+ValueError: Cause error
+
+
+

--- a/test/output/python3-vt100-ascii-color.out
+++ b/test/output/python3-vt100-ascii-color.out
@@ -209,3 +209,42 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_chaining.py
+
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 11, in cause
+    div(x, y)
+    [36m|   |  -> 0[m
+    [36m|   -> 1[m
+    [36m-> <function div at 0xDEADBEEF>[m
+  File "test/test_chaining.py", line 7, in div
+    x / y
+    [36m|   -> 0[m
+    [36m-> 1[m
+ZeroDivisionError: division by zero
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 17, in context
+    cause(x, y)
+    [36m|     |  -> 0[m
+    [36m|     -> 1[m
+    [36m-> <function cause at 0xDEADBEEF>[m
+  File "test/test_chaining.py", line 13, in cause
+    [33;1mraise[m [35;1mValueError[m([31m'Division error'[m)
+ValueError: Division error
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 21, in <module>
+    context([31m1[m, [31m0[m)
+    [36m-> <function context at 0xDEADBEEF>[m
+  File "test/test_chaining.py", line 19, in context
+    [33;1mraise[m [35;1mValueError[m([31m'Cause error'[m) from e
+ValueError: Cause error
+
+
+

--- a/test/output/python3-vt100-ascii-nocolor.out
+++ b/test/output/python3-vt100-ascii-nocolor.out
@@ -209,3 +209,42 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_chaining.py
+
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 11, in cause
+    div(x, y)
+    |   |  -> 0
+    |   -> 1
+    -> <function div at 0xDEADBEEF>
+  File "test/test_chaining.py", line 7, in div
+    x / y
+    |   -> 0
+    -> 1
+ZeroDivisionError: division by zero
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 17, in context
+    cause(x, y)
+    |     |  -> 0
+    |     -> 1
+    -> <function cause at 0xDEADBEEF>
+  File "test/test_chaining.py", line 13, in cause
+    raise ValueError("Division error")
+ValueError: Division error
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 21, in <module>
+    context(1, 0)
+    -> <function context at 0xDEADBEEF>
+  File "test/test_chaining.py", line 19, in context
+    raise ValueError("Cause error") from e
+ValueError: Cause error
+
+
+

--- a/test/output/python3-xterm-UTF-8-color.out
+++ b/test/output/python3-xterm-UTF-8-color.out
@@ -209,3 +209,42 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_chaining.py
+
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 11, in cause
+    div(x, y)
+    [36m│   │  └ 0[m
+    [36m│   └ 1[m
+    [36m└ <function div at 0xDEADBEEF>[m
+  File "test/test_chaining.py", line 7, in div
+    x / y
+    [36m│   └ 0[m
+    [36m└ 1[m
+ZeroDivisionError: division by zero
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 17, in context
+    cause(x, y)
+    [36m│     │  └ 0[m
+    [36m│     └ 1[m
+    [36m└ <function cause at 0xDEADBEEF>[m
+  File "test/test_chaining.py", line 13, in cause
+    [33;1mraise[m [35;1mValueError[m([31m'Division error'[m)
+ValueError: Division error
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 21, in <module>
+    context([31m1[m, [31m0[m)
+    [36m└ <function context at 0xDEADBEEF>[m
+  File "test/test_chaining.py", line 19, in context
+    [33;1mraise[m [35;1mValueError[m([31m'Cause error'[m) from e
+ValueError: Cause error
+
+
+

--- a/test/output/python3-xterm-UTF-8-nocolor.out
+++ b/test/output/python3-xterm-UTF-8-nocolor.out
@@ -209,3 +209,42 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_chaining.py
+
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 11, in cause
+    div(x, y)
+    │   │  └ 0
+    │   └ 1
+    └ <function div at 0xDEADBEEF>
+  File "test/test_chaining.py", line 7, in div
+    x / y
+    │   └ 0
+    └ 1
+ZeroDivisionError: division by zero
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 17, in context
+    cause(x, y)
+    │     │  └ 0
+    │     └ 1
+    └ <function cause at 0xDEADBEEF>
+  File "test/test_chaining.py", line 13, in cause
+    raise ValueError("Division error")
+ValueError: Division error
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 21, in <module>
+    context(1, 0)
+    └ <function context at 0xDEADBEEF>
+  File "test/test_chaining.py", line 19, in context
+    raise ValueError("Cause error") from e
+ValueError: Cause error
+
+
+

--- a/test/output/python3-xterm-ascii-color.out
+++ b/test/output/python3-xterm-ascii-color.out
@@ -209,3 +209,42 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_chaining.py
+
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 11, in cause
+    div(x, y)
+    [36m|   |  -> 0[m
+    [36m|   -> 1[m
+    [36m-> <function div at 0xDEADBEEF>[m
+  File "test/test_chaining.py", line 7, in div
+    x / y
+    [36m|   -> 0[m
+    [36m-> 1[m
+ZeroDivisionError: division by zero
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 17, in context
+    cause(x, y)
+    [36m|     |  -> 0[m
+    [36m|     -> 1[m
+    [36m-> <function cause at 0xDEADBEEF>[m
+  File "test/test_chaining.py", line 13, in cause
+    [33;1mraise[m [35;1mValueError[m([31m'Division error'[m)
+ValueError: Division error
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 21, in <module>
+    context([31m1[m, [31m0[m)
+    [36m-> <function context at 0xDEADBEEF>[m
+  File "test/test_chaining.py", line 19, in context
+    [33;1mraise[m [35;1mValueError[m([31m'Cause error'[m) from e
+ValueError: Cause error
+
+
+

--- a/test/output/python3-xterm-ascii-nocolor.out
+++ b/test/output/python3-xterm-ascii-nocolor.out
@@ -209,3 +209,42 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_chaining.py
+
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 11, in cause
+    div(x, y)
+    |   |  -> 0
+    |   -> 1
+    -> <function div at 0xDEADBEEF>
+  File "test/test_chaining.py", line 7, in div
+    x / y
+    |   -> 0
+    -> 1
+ZeroDivisionError: division by zero
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 17, in context
+    cause(x, y)
+    |     |  -> 0
+    |     -> 1
+    -> <function cause at 0xDEADBEEF>
+  File "test/test_chaining.py", line 13, in cause
+    raise ValueError("Division error")
+ValueError: Division error
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "test/test_chaining.py", line 21, in <module>
+    context(1, 0)
+    -> <function context at 0xDEADBEEF>
+  File "test/test_chaining.py", line 19, in context
+    raise ValueError("Cause error") from e
+ValueError: Cause error
+
+
+

--- a/test/test_chaining.py
+++ b/test/test_chaining.py
@@ -1,0 +1,21 @@
+# -*- coding:utf-8 -*-
+
+import better_exceptions
+better_exceptions.hook()
+
+def div(x, y):
+    x / y
+
+def cause(x, y):
+    try:
+        div(x, y)
+    except Exception:
+        raise ValueError("Division error")
+
+def context(x, y):
+    try:
+        cause(x, y)
+    except Exception as e:
+        raise ValueError("Cause error") from e
+
+context(1, 0)

--- a/test_all.sh
+++ b/test_all.sh
@@ -43,6 +43,10 @@ function test_all {
 	test_case "$BETEXC_PYTHON" "test/test_truncating_disabled.py"
 	test_case "$BETEXC_PYTHON" "test/test_indentation_error.py"
 	test_case "$BETEXC_PYTHON" "test/test_syntax_error.py"
+
+	if [[ "$BETEXC_PYTHON" == "python3" ]]; then
+		test_case "$BETEXC_PYTHON" "test/test_chaining.py"
+	fi
 }
 
 for encoding in ascii "UTF-8"; do


### PR DESCRIPTION
Hi again!

This is intended to implement exceptions chaining as suggested by #57.

Basically, I just copy-pasted the CPython implementation from [`traceback.py`](https://github.com/python/cpython/blob/a5b76167dedf4d15211a216c3ca7b98e3cec33b8/Lib/traceback.py#L468).
I refactored it to avoid carrying around another class, all is contained in a simple recursive generator function.

@Qix- I don't know if you have much time to review this. Nothing is urgent, I have others PR to prepare. 😛 