### PR TITLE
Align "format_traceback" output with built-in function

### DIFF
--- a/better_exceptions/__init__.py
+++ b/better_exceptions/__init__.py
@@ -46,11 +46,11 @@ def format_exception(exc, value, tb):
     # Rebuild each time to take into account any changes made by the user to the global parameters
     formatter = ExceptionFormatter(colored=SUPPORTS_COLOR, theme=THEME, max_length=MAX_LENGTH,
                                    pipe_char=PIPE_CHAR, cap_char=CAP_CHAR)
-    return formatter.format_exception(exc, value, tb)
+    return list(formatter.format_exception(exc, value, tb))
 
 
 def excepthook(exc, value, tb):
-    formatted = format_exception(exc, value, tb)
+    formatted = u''.join(format_exception(exc, value, tb))
     write_stream(formatted, STREAM)
 
 

--- a/better_exceptions/formatter.py
+++ b/better_exceptions/formatter.py
@@ -311,4 +311,5 @@ class ExceptionFormatter(object):
         yield u''.join(title).strip() + u'\n'
 
     def format_exception(self, exc, value, tb):
-        return u''.join(formatted for formatted in self._format_exception(value, tb))
+        for line in self._format_exception(value, tb):
+            yield line

--- a/better_exceptions/log.py
+++ b/better_exceptions/log.py
@@ -9,7 +9,7 @@ def patch():
     import logging
     from . import format_exception
 
-    logging_format_exception = lambda exc_info: format_exception(*exc_info)
+    logging_format_exception = lambda exc_info: u''.join(format_exception(*exc_info))
 
     if hasattr(logging, '_defaultFormatter'):
         logging._defaultFormatter.format_exception = logging_format_exception


### PR DESCRIPTION
As suggested by #58, this is just a slightly refactor of `better_exceptions.format_exception()` so that it returns a list of strings (rather than a string) as does the built-in [`traceback.format_exception()`](https://docs.python.org/3/library/traceback.html#traceback.format_exception).