### PR TITLE
Surround repr() with try / except in case object is unprintable

### DIFF
--- a/better_exceptions/formatter.py
+++ b/better_exceptions/formatter.py
@@ -113,7 +113,11 @@ class ExceptionFormatter(object):
         return [node for node in ast.walk(tree) if isinstance(node, ast.Name)]
 
     def format_value(self, v):
-        v = repr(v)
+        try:
+            v = repr(v)
+        except Exception:
+            v = u'<unprintable %s object>' % type(v).__name__
+
         max_length = self._max_length
         if max_length is not None and len(v) > max_length:
             v = v[:max_length] + '...'


### PR DESCRIPTION
It may happen that calling `repr()` on arbitrary object raises an exception. In such case, the error should be caught and some default string should be displayed instead. This is actually what is already done [in CPython](https://github.com/python/cpython/blob/91c6158dbc5d70fcd91993b4e62c7bae926c2ea2/Lib/traceback.py#L153-L157).