### PR TITLE
Write exception to stderr lazily

### DIFF
--- a/better_exceptions/__init__.py
+++ b/better_exceptions/__init__.py
@@ -42,16 +42,18 @@ def write_stream(data, stream=STREAM):
         stream.write(data)
 
 
-def format_exception(exc, value, tb):
+def formatter():
     # Rebuild each time to take into account any changes made by the user to the global parameters
-    formatter = ExceptionFormatter(colored=SUPPORTS_COLOR, theme=THEME, max_length=MAX_LENGTH,
-                                   pipe_char=PIPE_CHAR, cap_char=CAP_CHAR)
-    return list(formatter.format_exception(exc, value, tb))
+    return ExceptionFormatter(colored=SUPPORTS_COLOR, theme=THEME, max_length=MAX_LENGTH,
+                              pipe_char=PIPE_CHAR, cap_char=CAP_CHAR)
+
+def format_exception(exc, value, tb):
+    return list(formatter().format_exception(exc, value, tb))
 
 
 def excepthook(exc, value, tb):
-    formatted = u''.join(format_exception(exc, value, tb))
-    write_stream(formatted, STREAM)
+    for line in formatter().format_exception(exc, value, tb):
+        write_stream(line, STREAM)
 
 
 def hook():


### PR DESCRIPTION
In #37, user noticed that its program was hanging forever because of exception formatting.
Some weird asynchronous / recursive calls prevented `better_exceptions` to retrieve `repr(value)`.

I am not sure there is much we can do to fix it.
However, I think we can ease for the user the process of identifying the issue by displaying `better_exceptions` tracebacks progressively.

That is, if user remarks that its program is hanging forever, he will start investigating it, but I think it will take time before considering that the issue may come from the exception formatting.
However, by printing the exception line by line on our side, the user will see `Traceback (most recent call last):` and then nothing. So, he will immediately jump to the conclusion that maybe something is going wrong in `better_exceptions` hook.

@Qix- Do you think it worth merging it?