### PR TITLE
 Fix formatting of variables with multilines repr

### DIFF
--- a/better_exceptions/formatter.py
+++ b/better_exceptions/formatter.py
@@ -232,14 +232,24 @@ class ExceptionFormatter(object):
         for i in reversed(range(len(relevant_values))):
             _, col, val = relevant_values[i]
             pipe_cols = [pcol for _, pcol, _ in relevant_values[:i]]
-            line = ''
+            pre_line = ''
             index = 0
+
             for pc in pipe_cols:
-                line += (' ' * (pc - index)) + self._pipe_char
+                pre_line += (' ' * (pc - index)) + self._pipe_char
                 index = pc + 1
 
-            line += '{}{} {}'.format((' ' * (col - index)), self._cap_char, val)
-            lines.append(self._theme['inspect'](line) if self._colored else line)
+            pre_line += ' ' * (col - index)
+            val_lines = val.split('\n')
+
+            for n, val_line in enumerate(val_lines):
+                if n == 0:
+                    line = pre_line + self._cap_char + ' ' + val_line
+                else:
+                    line = pre_line + ' ' * (len(self._cap_char) + 1) + val_line
+
+                lines.append(self._theme['inspect'](line) if self._colored else line)
+
         formatted = '\n    '.join([to_unicode(x) for x in lines])
 
         return (filename, lineno, function, formatted), color_source

--- a/test/output/python-dumb-UTF-8-color.out
+++ b/test/output/python-dumb-UTF-8-color.out
@@ -248,3 +248,22 @@ ValueError: Cause error
 
 
 
+python test/test_multilines_repr.py
+
+
+Traceback (most recent call last):
+  File "test/test_multilines_repr.py", line 18, in <module>
+    multiline()
+    [36m└ <function multiline at 0xDEADBEEF>[m
+  File "test/test_multilines_repr.py", line 16, in multiline
+    a + b
+    [36m│   └ [[1, 2, 3][m
+    [36m│      [4, 5, 6][m
+    [36m│      [7, 8, 9]][m
+    [36m└ [[1, 2, 3][m
+    [36m   [4, 5, 6][m
+    [36m   [7, 8, 9]][m
+TypeError: unsupported operand type(s) for +: 'A' and 'A'
+
+
+

--- a/test/output/python-dumb-UTF-8-nocolor.out
+++ b/test/output/python-dumb-UTF-8-nocolor.out
@@ -248,3 +248,22 @@ ValueError: Cause error
 
 
 
+python test/test_multilines_repr.py
+
+
+Traceback (most recent call last):
+  File "test/test_multilines_repr.py", line 18, in <module>
+    multiline()
+    └ <function multiline at 0xDEADBEEF>
+  File "test/test_multilines_repr.py", line 16, in multiline
+    a + b
+    │   └ [[1, 2, 3]
+    │      [4, 5, 6]
+    │      [7, 8, 9]]
+    └ [[1, 2, 3]
+       [4, 5, 6]
+       [7, 8, 9]]
+TypeError: unsupported operand type(s) for +: 'A' and 'A'
+
+
+

--- a/test/output/python-dumb-ascii-color.out
+++ b/test/output/python-dumb-ascii-color.out
@@ -248,3 +248,22 @@ ValueError: Cause error
 
 
 
+python test/test_multilines_repr.py
+
+
+Traceback (most recent call last):
+  File "test/test_multilines_repr.py", line 18, in <module>
+    multiline()
+    [36m-> <function multiline at 0xDEADBEEF>[m
+  File "test/test_multilines_repr.py", line 16, in multiline
+    a + b
+    [36m|   -> [[1, 2, 3][m
+    [36m|       [4, 5, 6][m
+    [36m|       [7, 8, 9]][m
+    [36m-> [[1, 2, 3][m
+    [36m    [4, 5, 6][m
+    [36m    [7, 8, 9]][m
+TypeError: unsupported operand type(s) for +: 'A' and 'A'
+
+
+

--- a/test/output/python-dumb-ascii-nocolor.out
+++ b/test/output/python-dumb-ascii-nocolor.out
@@ -248,3 +248,22 @@ ValueError: Cause error
 
 
 
+python test/test_multilines_repr.py
+
+
+Traceback (most recent call last):
+  File "test/test_multilines_repr.py", line 18, in <module>
+    multiline()
+    -> <function multiline at 0xDEADBEEF>
+  File "test/test_multilines_repr.py", line 16, in multiline
+    a + b
+    |   -> [[1, 2, 3]
+    |       [4, 5, 6]
+    |       [7, 8, 9]]
+    -> [[1, 2, 3]
+        [4, 5, 6]
+        [7, 8, 9]]
+TypeError: unsupported operand type(s) for +: 'A' and 'A'
+
+
+

--- a/test/output/python-vt100-UTF-8-color.out
+++ b/test/output/python-vt100-UTF-8-color.out
@@ -248,3 +248,22 @@ ValueError: Cause error
 
 
 
+python test/test_multilines_repr.py
+
+
+Traceback (most recent call last):
+  File "test/test_multilines_repr.py", line 18, in <module>
+    multiline()
+    [36m└ <function multiline at 0xDEADBEEF>[m
+  File "test/test_multilines_repr.py", line 16, in multiline
+    a + b
+    [36m│   └ [[1, 2, 3][m
+    [36m│      [4, 5, 6][m
+    [36m│      [7, 8, 9]][m
+    [36m└ [[1, 2, 3][m
+    [36m   [4, 5, 6][m
+    [36m   [7, 8, 9]][m
+TypeError: unsupported operand type(s) for +: 'A' and 'A'
+
+
+

--- a/test/output/python-vt100-UTF-8-nocolor.out
+++ b/test/output/python-vt100-UTF-8-nocolor.out
@@ -248,3 +248,22 @@ ValueError: Cause error
 
 
 
+python test/test_multilines_repr.py
+
+
+Traceback (most recent call last):
+  File "test/test_multilines_repr.py", line 18, in <module>
+    multiline()
+    └ <function multiline at 0xDEADBEEF>
+  File "test/test_multilines_repr.py", line 16, in multiline
+    a + b
+    │   └ [[1, 2, 3]
+    │      [4, 5, 6]
+    │      [7, 8, 9]]
+    └ [[1, 2, 3]
+       [4, 5, 6]
+       [7, 8, 9]]
+TypeError: unsupported operand type(s) for +: 'A' and 'A'
+
+
+

--- a/test/output/python-vt100-ascii-color.out
+++ b/test/output/python-vt100-ascii-color.out
@@ -248,3 +248,22 @@ ValueError: Cause error
 
 
 
+python test/test_multilines_repr.py
+
+
+Traceback (most recent call last):
+  File "test/test_multilines_repr.py", line 18, in <module>
+    multiline()
+    [36m-> <function multiline at 0xDEADBEEF>[m
+  File "test/test_multilines_repr.py", line 16, in multiline
+    a + b
+    [36m|   -> [[1, 2, 3][m
+    [36m|       [4, 5, 6][m
+    [36m|       [7, 8, 9]][m
+    [36m-> [[1, 2, 3][m
+    [36m    [4, 5, 6][m
+    [36m    [7, 8, 9]][m
+TypeError: unsupported operand type(s) for +: 'A' and 'A'
+
+
+

--- a/test/output/python-vt100-ascii-nocolor.out
+++ b/test/output/python-vt100-ascii-nocolor.out
@@ -248,3 +248,22 @@ ValueError: Cause error
 
 
 
+python test/test_multilines_repr.py
+
+
+Traceback (most recent call last):
+  File "test/test_multilines_repr.py", line 18, in <module>
+    multiline()
+    -> <function multiline at 0xDEADBEEF>
+  File "test/test_multilines_repr.py", line 16, in multiline
+    a + b
+    |   -> [[1, 2, 3]
+    |       [4, 5, 6]
+    |       [7, 8, 9]]
+    -> [[1, 2, 3]
+        [4, 5, 6]
+        [7, 8, 9]]
+TypeError: unsupported operand type(s) for +: 'A' and 'A'
+
+
+

--- a/test/output/python-xterm-UTF-8-color.out
+++ b/test/output/python-xterm-UTF-8-color.out
@@ -248,3 +248,22 @@ ValueError: Cause error
 
 
 
+python test/test_multilines_repr.py
+
+
+Traceback (most recent call last):
+  File "test/test_multilines_repr.py", line 18, in <module>
+    multiline()
+    [36m└ <function multiline at 0xDEADBEEF>[m
+  File "test/test_multilines_repr.py", line 16, in multiline
+    a + b
+    [36m│   └ [[1, 2, 3][m
+    [36m│      [4, 5, 6][m
+    [36m│      [7, 8, 9]][m
+    [36m└ [[1, 2, 3][m
+    [36m   [4, 5, 6][m
+    [36m   [7, 8, 9]][m
+TypeError: unsupported operand type(s) for +: 'A' and 'A'
+
+
+

--- a/test/output/python-xterm-UTF-8-nocolor.out
+++ b/test/output/python-xterm-UTF-8-nocolor.out
@@ -248,3 +248,22 @@ ValueError: Cause error
 
 
 
+python test/test_multilines_repr.py
+
+
+Traceback (most recent call last):
+  File "test/test_multilines_repr.py", line 18, in <module>
+    multiline()
+    └ <function multiline at 0xDEADBEEF>
+  File "test/test_multilines_repr.py", line 16, in multiline
+    a + b
+    │   └ [[1, 2, 3]
+    │      [4, 5, 6]
+    │      [7, 8, 9]]
+    └ [[1, 2, 3]
+       [4, 5, 6]
+       [7, 8, 9]]
+TypeError: unsupported operand type(s) for +: 'A' and 'A'
+
+
+

--- a/test/output/python-xterm-ascii-color.out
+++ b/test/output/python-xterm-ascii-color.out
@@ -248,3 +248,22 @@ ValueError: Cause error
 
 
 
+python test/test_multilines_repr.py
+
+
+Traceback (most recent call last):
+  File "test/test_multilines_repr.py", line 18, in <module>
+    multiline()
+    [36m-> <function multiline at 0xDEADBEEF>[m
+  File "test/test_multilines_repr.py", line 16, in multiline
+    a + b
+    [36m|   -> [[1, 2, 3][m
+    [36m|       [4, 5, 6][m
+    [36m|       [7, 8, 9]][m
+    [36m-> [[1, 2, 3][m
+    [36m    [4, 5, 6][m
+    [36m    [7, 8, 9]][m
+TypeError: unsupported operand type(s) for +: 'A' and 'A'
+
+
+

--- a/test/output/python-xterm-ascii-nocolor.out
+++ b/test/output/python-xterm-ascii-nocolor.out
@@ -248,3 +248,22 @@ ValueError: Cause error
 
 
 
+python test/test_multilines_repr.py
+
+
+Traceback (most recent call last):
+  File "test/test_multilines_repr.py", line 18, in <module>
+    multiline()
+    -> <function multiline at 0xDEADBEEF>
+  File "test/test_multilines_repr.py", line 16, in multiline
+    a + b
+    |   -> [[1, 2, 3]
+    |       [4, 5, 6]
+    |       [7, 8, 9]]
+    -> [[1, 2, 3]
+        [4, 5, 6]
+        [7, 8, 9]]
+TypeError: unsupported operand type(s) for +: 'A' and 'A'
+
+
+

--- a/test/test_multilines_repr.py
+++ b/test/test_multilines_repr.py
@@ -1,0 +1,18 @@
+# -*- coding:utf-8 -*-
+
+import better_exceptions
+better_exceptions.hook()
+
+
+class A:
+
+    def __repr__(self):
+        return ("[[1, 2, 3]\n"
+                " [4, 5, 6]\n"
+                " [7, 8, 9]]")
+
+def multiline():
+    a = b = A()
+    a + b
+
+multiline()

--- a/test_all.sh
+++ b/test_all.sh
@@ -44,6 +44,7 @@ function test_all {
 	test_case "$BETEXC_PYTHON" "test/test_indentation_error.py"
 	test_case "$BETEXC_PYTHON" "test/test_syntax_error.py"
 	test_case "$BETEXC_PYTHON" "test/test_chaining.py"
+	test_case "$BETEXC_PYTHON" "test/test_multilines_repr.py"
 }
 
 for encoding in ascii "UTF-8"; do


### PR DESCRIPTION
I noticed that objects with a representation standing on several lines was breaking the formatting. This is particularly the case for `numpy` arrays.

```
Traceback (most recent call last):
  File "a.py", line 16, in <module>
    multiline()
    └ <function multiline at 0x7f7acc1adb70>
  File "a.py", line 14, in multiline
    a + b
    │   └ [[1, 2, 3]
 [4, 5, 6]
 [7, 8, 9]]
    └ [[1, 2, 3]
 [4, 5, 6]
 [7, 8, 9]]
TypeError: unsupported operand type(s) for +: 'A' and 'A'
```

With this fix, it would look like this:

```
Traceback (most recent call last):
  File "a.py", line 16, in <module>
    multiline()
    └ <function multiline at 0x7f355a9edbf8>
  File "a.py", line 14, in multiline
    a + b
    │   └ [[1, 2, 3]
    │      [4, 5, 6]
    │      [7, 8, 9]]
    └ [[1, 2, 3]
       [4, 5, 6]
       [7, 8, 9]]
TypeError: unsupported operand type(s) for +: 'A' and 'A'
```