### PR TITLE
Fix some formatting issues by replacing parser with lexer

### DIFF
--- a/better_exceptions/__init__.py
+++ b/better_exceptions/__init__.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 import logging
 import sys
 
-from .formatter import THEME, MAX_LENGTH, PIPE_CHAR, CAP_CHAR, ExceptionFormatter
+from .formatter import STYLE, THEME, MAX_LENGTH, PIPE_CHAR, CAP_CHAR, ExceptionFormatter
 from .encoding import to_byte
 from .color import SUPPORTS_COLOR, SHOULD_ENCODE, STREAM
 from .log import BetExcLogger, patch as patch_logging
@@ -24,9 +24,6 @@ from .repl import interact, get_repl
 
 
 __version__ = '0.2.2'
-
-
-THEME = THEME.copy()  # Users customizing the theme should not impact core
 
 
 def write_stream(data, stream=STREAM):
@@ -39,8 +36,10 @@ def write_stream(data, stream=STREAM):
 
 def format_exception(exc, value, tb):
     # Rebuild each time to take into account any changes made by the user to the global parameters
-    formatter = ExceptionFormatter(colored=SUPPORTS_COLOR, theme=THEME, max_length=MAX_LENGTH,
-                                   pipe_char=PIPE_CHAR, cap_char=CAP_CHAR)
+    formatter = ExceptionFormatter(
+        colored=SUPPORTS_COLOR, style=STYLE,theme=THEME, max_length=MAX_LENGTH,
+        pipe_char=PIPE_CHAR, cap_char=CAP_CHAR
+    )
     return list(formatter.format_exception(exc, value, tb))
 
 

--- a/better_exceptions/formatter.py
+++ b/better_exceptions/formatter.py
@@ -1,16 +1,17 @@
 from __future__ import absolute_import
 
-import ast
 import inspect
 import keyword
 import linecache
 import os
 import re
 import sys
+import tokenize
 import traceback
 
 from .color import STREAM, SUPPORTS_COLOR
 from .encoding import ENCODING, to_byte, to_unicode
+from .highlighter import STYLE, Highlighter
 from .repl import get_repl
 
 
@@ -24,92 +25,24 @@ except UnicodeEncodeError:
     CAP_CHAR = '->'
 
 THEME = {
-    'comment': lambda s: '\x1b[2;37m{}\x1b[m'.format(s),
-    'keyword': lambda s: '\x1b[33;1m{}\x1b[m'.format(s),
-    'builtin': lambda s: '\x1b[35;1m{}\x1b[m'.format(s),
-    'literal': lambda s: '\x1b[31m{}\x1b[m'.format(s),
-    'inspect': lambda s: '\x1b[36m{}\x1b[m'.format(s),
+    'inspect': '\x1b[36m{}\x1b[m',
 }
 
 MAX_LENGTH = 128
 
 
-def isast(v):
-    return inspect.isclass(v) and issubclass(v, ast.AST)
-
-
 class ExceptionFormatter(object):
 
-    COMMENT_REGXP = re.compile(r'((?:(?:"(?:[^\\"]|(\\\\)*\\")*")|(?:\'(?:[^\\"]|(\\\\)*\\\')*\')|[^#])*)(#.*)$')
     CMDLINE_REGXP = re.compile(r'(?:[^\t ]*([\'"])(?:\\.|.)*(?:\1))[^\t ]*|([^\t ]+)')
 
-    AST_ELEMENTS = {
-        'builtins': __builtins__.keys() if type(__builtins__) is dict else dir(__builtins__),
-        'keywords': [getattr(ast, cls) for cls in dir(ast) if keyword.iskeyword(cls.lower()) and isast(getattr(ast, cls))],
-    }
-
-    def __init__(self, colored=SUPPORTS_COLOR, theme=THEME, max_length=MAX_LENGTH,
+    def __init__(self, colored=SUPPORTS_COLOR, style=STYLE, theme=THEME, max_length=MAX_LENGTH,
                        pipe_char=PIPE_CHAR, cap_char=CAP_CHAR):
         self._colored = colored
         self._theme = theme
         self._max_length = max_length
         self._pipe_char = pipe_char
         self._cap_char = cap_char
-
-    def colorize_comment(self, source):
-        match = self.COMMENT_REGXP.match(source)
-        if match:
-            source = '{}{}'.format(match.group(1), self._theme['comment'](match.group(4)))
-        return source
-
-    def colorize_tree(self, tree, source):
-        if not self._colored:
-            # quick fail
-            return source
-
-        chunks = []
-
-        offset = 0
-        nodes = [n for n in ast.walk(tree)]
-
-        def append(offset, node, s, theme):
-            begin_col = node.col_offset
-            src_chunk = source[offset:begin_col]
-            chunks.append(src_chunk)
-            chunks.append(self._theme[theme](s))
-            return begin_col + len(s)
-
-        displayed_nodes = []
-
-        for node in nodes:
-            nodecls = node.__class__
-            nodename = nodecls.__name__
-
-            if 'col_offset' not in dir(node):
-                continue
-
-            if nodecls in self.AST_ELEMENTS['keywords']:
-                displayed_nodes.append((node, nodename.lower(), 'keyword'))
-
-            if nodecls == ast.Name and node.id in self.AST_ELEMENTS['builtins']:
-                displayed_nodes.append((node, node.id, 'builtin'))
-
-            if nodecls == ast.Str:
-                displayed_nodes.append((node, "'{}'".format(node.s), 'literal'))
-
-            if nodecls == ast.Num:
-                displayed_nodes.append((node, str(node.n), 'literal'))
-
-        displayed_nodes.sort(key=lambda elem: elem[0].col_offset)
-
-        for dn in displayed_nodes:
-            offset = append(offset, *dn)
-
-        chunks.append(source[offset:])
-        return self.colorize_comment(''.join(chunks))
-
-    def get_relevant_names(self, source, tree):
-        return [node for node in ast.walk(tree) if isinstance(node, ast.Name)]
+        self._highlighter = Highlighter(style)
 
     def format_value(self, v):
         try:
@@ -122,21 +55,27 @@ class ExceptionFormatter(object):
             v = v[:max_length] + '...'
         return v
 
-    def get_relevant_values(self, source, frame, tree):
-        names = self.get_relevant_names(source, tree)
+    def get_relevant_names(self, source):
+        for token in self._highlighter.tokenize(source):
+            if token.type != tokenize.NAME:
+                continue
+
+            if not keyword.iskeyword(token.string):
+                yield token.string, token.start[1]
+
+    def get_relevant_values(self, source, frame):
+        names = self.get_relevant_names(source)
         values = []
 
-        for name in names:
-            text = name.id
-            col = name.col_offset
-            if text in frame.f_locals:
-                val = frame.f_locals.get(text, None)
-                values.append((text, col, self.format_value(val)))
-            elif text in frame.f_globals:
-                val = frame.f_globals.get(text, None)
-                values.append((text, col, self.format_value(val)))
+        for name, col in names:
+            if name in frame.f_locals:
+                val = frame.f_locals.get(name, None)
+                values.append((col, self.format_value(val)))
+            elif name in frame.f_globals:
+                val = frame.f_globals.get(name, None)
+                values.append((col, self.format_value(val)))
 
-        values.sort(key=lambda e: e[1])
+        values.sort()
 
         return values
 
@@ -214,13 +153,12 @@ class ExceptionFormatter(object):
 
         source = source.strip()
 
-        try:
-            tree = ast.parse(source, mode='exec')
-        except SyntaxError:
-            return filename, lineno, function, source, source, []
+        relevant_values = self.get_relevant_values(source, tb.tb_frame)
 
-        relevant_values = self.get_relevant_values(source, tb.tb_frame, tree)
-        color_source = self.colorize_tree(tree, source)
+        if self._colored:
+            color_source = self._highlighter.highlight(source)
+        else:
+            color_source = source
 
         return filename, lineno, function, source, color_source, relevant_values
 
@@ -230,8 +168,8 @@ class ExceptionFormatter(object):
 
         lines = [color_source]
         for i in reversed(range(len(relevant_values))):
-            _, col, val = relevant_values[i]
-            pipe_cols = [pcol for _, pcol, _ in relevant_values[:i]]
+            col, val = relevant_values[i]
+            pipe_cols = [pcol for pcol, _ in relevant_values[:i]]
             pre_line = ''
             index = 0
 
@@ -248,7 +186,7 @@ class ExceptionFormatter(object):
                 else:
                     line = pre_line + ' ' * (len(self._cap_char) + 1) + val_line
 
-                lines.append(self._theme['inspect'](line) if self._colored else line)
+                lines.append(self._theme['inspect'].format(line) if self._colored else line)
 
         formatted = '\n    '.join([to_unicode(x) for x in lines])
 

--- a/better_exceptions/highlighter.py
+++ b/better_exceptions/highlighter.py
@@ -1,0 +1,85 @@
+import builtins
+import io
+import keyword
+import tokenize
+
+
+STYLE = {
+    'builtin': '\x1b[35;1m{}\x1b[m',
+    'comment': '\x1b[2;37m{}\x1b[m',
+    'constant': '{}',
+    'identifier': '{}',
+    'keyword': '\x1b[33;1m{}\x1b[m',
+    'number': '\x1b[31m{}\x1b[m',
+    'operator': '{}',
+    'other': '{}',
+    'punctuation': '{}',
+    'string': '\x1b[31m{}\x1b[m',
+}
+
+
+class Highlighter(object):
+
+    def __init__(self, style):
+        self._style = style
+        self._builtins = dir(builtins)
+        self._punctation = {'(', ')', '[', ']', '{', '}', ':', ',', ';'}
+        self._constants = {'True', 'False', 'None'}
+
+    def highlight(self, source):
+        style = self._style
+        row, column = 0, 0
+        output = ""
+
+        for token in self.tokenize(source):
+            type_, string, start, end, line = token
+
+            if type_ == tokenize.NAME:
+                if string in self._constants:
+                    color = style['constant']
+                elif keyword.iskeyword(string):
+                    color = style['keyword']
+                elif string in self._builtins:
+                    color = style['builtin']
+                else:
+                    color = style['identifier']
+            elif type_ == tokenize.OP:
+                if string in self._punctation:
+                    color = style['punctuation']
+                else:
+                    color = style['operator']
+            elif type_ == tokenize.NUMBER:
+                color = style['number']
+            elif type_ == tokenize.STRING:
+                color = style['string']
+            elif type_ == tokenize.COMMENT:
+                color = style['comment']
+            else:
+                color = style['other']
+
+            start_row, start_column = start
+            _, end_column = end
+
+            if start_row != row:
+                source = source[:column]
+                row, column = start_row, 0
+
+            if type_ != tokenize.ENCODING:
+                output += line[column:start_column]
+                output += color.format(string)
+
+            column = end_column
+
+        output += source[column:]
+
+        return output
+
+    @staticmethod
+    def tokenize(source):
+        source = source.encode("utf-8")
+        source = io.BytesIO(source)
+
+        try:
+            yield from tokenize.tokenize(source.readline)
+        except tokenize.TokenError:
+            return

--- a/test/output/python-dumb-UTF-8-color.out
+++ b/test/output/python-dumb-UTF-8-color.out
@@ -12,10 +12,10 @@ Traceback (most recent call last):
     [36m│    └ 2[m
     [36m└ <function deep at 0xDEADBEEF>[m
   File "test/test.py", line 13, in deep
-    [33;1massert[m val > [31m10[m and foo == [31m60[m
+    [33;1massert[m val > [31m10[m [33;1mand[m foo == [31m60[m
     [36m       │            └ 52[m
     [36m       └ 17[m
-AssertionError: [33;1massert[m val > [31m10[m and foo == [31m60[m
+AssertionError: [33;1massert[m val > [31m10[m [33;1mand[m foo == [31m60[m
 
 
 
@@ -34,7 +34,7 @@ Traceback (most recent call last):
     div()
     [36m└ <function div at 0xDEADBEEF>[m
   File "test/test_encoding.py", line 11, in div
-    [33;1mreturn[m _deep([31m'天'[m)
+    [33;1mreturn[m _deep([31m"天"[m)
     [36m       └ <function _deep at 0xDEADBEEF>[m
   File "test/test_encoding.py", line 8, in _deep
     [33;1mreturn[m [31m1[m / val
@@ -73,57 +73,67 @@ import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m5[m; [33;1massert[m a > [31m10[m [2;37m# this should work fine[m
-    [36m                          │                         │             └ 5[m
-    [36m                          │                         └ 5[m
-    [36m                          └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m       │                  │                         │             └ 5[m
+    [36m       │                  │                         └ 5[m
+    [36m       │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m       └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
 AssertionError: [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m5[m; [33;1massert[m a > [31m10[m [2;37m# this should work fine[m
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m5[m; [33;1massert[m a > [31m10[m [2;37m# this should work fine[m
-    [36m                          │                         │             └ 5[m
-    [36m                          │                         └ 5[m
-    [36m                          └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m       │                  │                         │             └ 5[m
+    [36m       │                  │                         └ 5[m
+    [36m       │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m       └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
 AssertionError: [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m5[m; [33;1massert[m a > [31m10[m [2;37m# this should work fine[m
 
 from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-    from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why hello there'[m; [35;1mprint[m(a); [33;1massert[m False
-    [36m                                                                 │                         │                            └ 'why hello there'[m
-    [36m                                                                 │                         └ 'why hello there'[m
-    [36m                                                                 └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
-AssertionError: from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why hello there'[m; [35;1mprint[m(a); [33;1massert[m False
+    [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why hello there"[m; [35;1mprint[m(a); [33;1massert[m False
+    [36m                       │                      │                  │                         │                            └ 'why hello there'[m
+    [36m                       │                      │                  │                         └ 'why hello there'[m
+    [36m                       │                      │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       │                      └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       └ _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)[m
+AssertionError: [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why hello there"[m; [35;1mprint[m(a); [33;1massert[m False
 why hello there
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-    from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why hello there'[m; [35;1mprint[m(a); [33;1massert[m False
-    [36m                                                                 │                         │                            └ 'why hello there'[m
-    [36m                                                                 │                         └ 'why hello there'[m
-    [36m                                                                 └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
-AssertionError: from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why hello there'[m; [35;1mprint[m(a); [33;1massert[m False
+    [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why hello there"[m; [35;1mprint[m(a); [33;1massert[m False
+    [36m                       │                      │                  │                         │                            └ 'why hello there'[m
+    [36m                       │                      │                  │                         └ 'why hello there'[m
+    [36m                       │                      │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       │                      └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       └ _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)[m
+AssertionError: [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why hello there"[m; [35;1mprint[m(a); [33;1massert[m False
 why hello there
 
 from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-    from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why     hello          '[m + [31m'   there'[m; [35;1mprint[m(a); [33;1massert[m False
-    [36m                                                                 │                         │                                                 └ 'why     hello             there'[m
-    [36m                                                                 │                         └ 'why     hello             there'[m
-    [36m                                                                 └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
-AssertionError: from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why     hello          '[m + [31m'   there'[m; [35;1mprint[m(a); [33;1massert[m False
+    [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why     hello          "[m + [31m"   there"[m; [35;1mprint[m(a); [33;1massert[m False
+    [36m                       │                      │                  │                         │                                                 └ 'why     hello             there'[m
+    [36m                       │                      │                  │                         └ 'why     hello             there'[m
+    [36m                       │                      │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       │                      └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       └ _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)[m
+AssertionError: [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why     hello          "[m + [31m"   there"[m; [35;1mprint[m(a); [33;1massert[m False
 why     hello             there
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-    from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why     hello          '[m + [31m'   there'[m; [35;1mprint[m(a); [33;1massert[m False
-    [36m                                                                 │                         │                                                 └ 'why     hello             there'[m
-    [36m                                                                 │                         └ 'why     hello             there'[m
-    [36m                                                                 └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
-AssertionError: from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why     hello          '[m + [31m'   there'[m; [35;1mprint[m(a); [33;1massert[m False
+    [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why     hello          "[m + [31m"   there"[m; [35;1mprint[m(a); [33;1massert[m False
+    [36m                       │                      │                  │                         │                                                 └ 'why     hello             there'[m
+    [36m                       │                      │                  │                         └ 'why     hello             there'[m
+    [36m                       │                      │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       │                      └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       └ _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)[m
+AssertionError: [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why     hello          "[m + [31m"   there"[m; [35;1mprint[m(a); [33;1massert[m False
 why     hello             there
 
 
@@ -233,7 +243,7 @@ Traceback (most recent call last):
     [36m│     └ 1[m
     [36m└ <function cause at 0xDEADBEEF>[m
   File "test/test_chaining.py", line 13, in cause
-    [33;1mraise[m [35;1mValueError[m([31m'Division error'[m)
+    [33;1mraise[m [35;1mValueError[m([31m"Division error"[m)
 ValueError: Division error
 
 The above exception was the direct cause of the following exception:
@@ -243,7 +253,7 @@ Traceback (most recent call last):
     context([31m1[m, [31m0[m)
     [36m└ <function context at 0xDEADBEEF>[m
   File "test/test_chaining.py", line 19, in context
-    [33;1mraise[m [35;1mValueError[m([31m'Cause error'[m) from e
+    [33;1mraise[m [35;1mValueError[m([31m"Cause error"[m) [33;1mfrom[m e
 ValueError: Cause error
 
 
@@ -264,6 +274,35 @@ Traceback (most recent call last):
     [36m   [4, 5, 6][m
     [36m   [7, 8, 9]][m
 TypeError: unsupported operand type(s) for +: 'A' and 'A'
+
+
+
+python test/test_source_multilines.py
+
+
+Traceback (most recent call last):
+  File "test/test_source_multilines.py", line 16, in <module>
+    """)
+  File "test/test_source_multilines.py", line 13, in test
+    , string, [31m3[m)
+    [36m  └ 'multi-lines\n'[m
+  File "test/test_source_multilines.py", line 8, in add
+    [33;1mreturn[m (a + b + \
+    [36m        │   └ 'multi-lines\n'[m
+    [36m        └ 1[m
+TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+
+
+python test/test_source_strings.py
+
+
+Traceback (most recent call last):
+  File "test/test_source_strings.py", line 8, in <module>
+    a + [31mb"prefix"[m + [31m'single'[m + [31m"""triple"""[m + [31m1[m + b
+    [36m│                                             └ 0[m
+    [36m└ 0[m
+TypeError: unsupported operand type(s) for +: 'int' and 'bytes'
 
 
 

--- a/test/output/python-dumb-UTF-8-nocolor.out
+++ b/test/output/python-dumb-UTF-8-nocolor.out
@@ -73,17 +73,19 @@ import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this should work fine
-                              │                         │             └ 5
-                              │                         └ 5
-                              └ <module 'test_module' from '/removed/for/test/purposes.py'>
+           │                  │                         │             └ 5
+           │                  │                         └ 5
+           │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>
+           └ <module 'test_module' from '/removed/for/test/purposes.py'>
 AssertionError: import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this should work fine
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this should work fine
-                              │                         │             └ 5
-                              │                         └ 5
-                              └ <module 'test_module' from '/removed/for/test/purposes.py'>
+           │                  │                         │             └ 5
+           │                  │                         └ 5
+           │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>
+           └ <module 'test_module' from '/removed/for/test/purposes.py'>
 AssertionError: import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this should work fine
 
 from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
@@ -91,18 +93,22 @@ from __future__ import print_function; import better_exceptions; better_exceptio
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
-                                                                     │                         │                            └ 'why hello there'
-                                                                     │                         └ 'why hello there'
-                                                                     └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           │                      │                  │                         │                            └ 'why hello there'
+                           │                      │                  │                         └ 'why hello there'
+                           │                      │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           │                      └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           └ _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)
 AssertionError: from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
 why hello there
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
-                                                                     │                         │                            └ 'why hello there'
-                                                                     │                         └ 'why hello there'
-                                                                     └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           │                      │                  │                         │                            └ 'why hello there'
+                           │                      │                  │                         └ 'why hello there'
+                           │                      │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           │                      └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           └ _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)
 AssertionError: from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
 why hello there
 
@@ -111,18 +117,22 @@ from __future__ import print_function; import better_exceptions; better_exceptio
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
-                                                                     │                         │                                                 └ 'why     hello             there'
-                                                                     │                         └ 'why     hello             there'
-                                                                     └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           │                      │                  │                         │                                                 └ 'why     hello             there'
+                           │                      │                  │                         └ 'why     hello             there'
+                           │                      │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           │                      └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           └ _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)
 AssertionError: from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
 why     hello             there
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
-                                                                     │                         │                                                 └ 'why     hello             there'
-                                                                     │                         └ 'why     hello             there'
-                                                                     └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           │                      │                  │                         │                                                 └ 'why     hello             there'
+                           │                      │                  │                         └ 'why     hello             there'
+                           │                      │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           │                      └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           └ _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)
 AssertionError: from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
 why     hello             there
 
@@ -264,6 +274,35 @@ Traceback (most recent call last):
        [4, 5, 6]
        [7, 8, 9]]
 TypeError: unsupported operand type(s) for +: 'A' and 'A'
+
+
+
+python test/test_source_multilines.py
+
+
+Traceback (most recent call last):
+  File "test/test_source_multilines.py", line 16, in <module>
+    """)
+  File "test/test_source_multilines.py", line 13, in test
+    , string, 3)
+      └ 'multi-lines\n'
+  File "test/test_source_multilines.py", line 8, in add
+    return (a + b + \
+            │   └ 'multi-lines\n'
+            └ 1
+TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+
+
+python test/test_source_strings.py
+
+
+Traceback (most recent call last):
+  File "test/test_source_strings.py", line 8, in <module>
+    a + b"prefix" + 'single' + """triple""" + 1 + b
+    │                                             └ 0
+    └ 0
+TypeError: unsupported operand type(s) for +: 'int' and 'bytes'
 
 
 

--- a/test/output/python-dumb-ascii-color.out
+++ b/test/output/python-dumb-ascii-color.out
@@ -12,10 +12,10 @@ Traceback (most recent call last):
     [36m|    -> 2[m
     [36m-> <function deep at 0xDEADBEEF>[m
   File "test/test.py", line 13, in deep
-    [33;1massert[m val > [31m10[m and foo == [31m60[m
+    [33;1massert[m val > [31m10[m [33;1mand[m foo == [31m60[m
     [36m       |            -> 52[m
     [36m       -> 17[m
-AssertionError: [33;1massert[m val > [31m10[m and foo == [31m60[m
+AssertionError: [33;1massert[m val > [31m10[m [33;1mand[m foo == [31m60[m
 
 
 
@@ -34,7 +34,7 @@ Traceback (most recent call last):
     div()
     [36m-> <function div at 0xDEADBEEF>[m
   File "test/test_encoding.py", line 11, in div
-    [33;1mreturn[m _deep([31m'天'[m)
+    [33;1mreturn[m _deep([31m"天"[m)
     [36m       -> <function _deep at 0xDEADBEEF>[m
   File "test/test_encoding.py", line 8, in _deep
     [33;1mreturn[m [31m1[m / val
@@ -73,57 +73,67 @@ import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m5[m; [33;1massert[m a > [31m10[m [2;37m# this should work fine[m
-    [36m                          |                         |             -> 5[m
-    [36m                          |                         -> 5[m
-    [36m                          -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m       |                  |                         |             -> 5[m
+    [36m       |                  |                         -> 5[m
+    [36m       |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m       -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
 AssertionError: [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m5[m; [33;1massert[m a > [31m10[m [2;37m# this should work fine[m
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m5[m; [33;1massert[m a > [31m10[m [2;37m# this should work fine[m
-    [36m                          |                         |             -> 5[m
-    [36m                          |                         -> 5[m
-    [36m                          -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m       |                  |                         |             -> 5[m
+    [36m       |                  |                         -> 5[m
+    [36m       |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m       -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
 AssertionError: [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m5[m; [33;1massert[m a > [31m10[m [2;37m# this should work fine[m
 
 from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-    from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why hello there'[m; [35;1mprint[m(a); [33;1massert[m False
-    [36m                                                                 |                         |                            -> 'why hello there'[m
-    [36m                                                                 |                         -> 'why hello there'[m
-    [36m                                                                 -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
-AssertionError: from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why hello there'[m; [35;1mprint[m(a); [33;1massert[m False
+    [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why hello there"[m; [35;1mprint[m(a); [33;1massert[m False
+    [36m                       |                      |                  |                         |                            -> 'why hello there'[m
+    [36m                       |                      |                  |                         -> 'why hello there'[m
+    [36m                       |                      |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       |                      -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       -> _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)[m
+AssertionError: [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why hello there"[m; [35;1mprint[m(a); [33;1massert[m False
 why hello there
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-    from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why hello there'[m; [35;1mprint[m(a); [33;1massert[m False
-    [36m                                                                 |                         |                            -> 'why hello there'[m
-    [36m                                                                 |                         -> 'why hello there'[m
-    [36m                                                                 -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
-AssertionError: from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why hello there'[m; [35;1mprint[m(a); [33;1massert[m False
+    [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why hello there"[m; [35;1mprint[m(a); [33;1massert[m False
+    [36m                       |                      |                  |                         |                            -> 'why hello there'[m
+    [36m                       |                      |                  |                         -> 'why hello there'[m
+    [36m                       |                      |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       |                      -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       -> _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)[m
+AssertionError: [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why hello there"[m; [35;1mprint[m(a); [33;1massert[m False
 why hello there
 
 from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-    from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why     hello          '[m + [31m'   there'[m; [35;1mprint[m(a); [33;1massert[m False
-    [36m                                                                 |                         |                                                 -> 'why     hello             there'[m
-    [36m                                                                 |                         -> 'why     hello             there'[m
-    [36m                                                                 -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
-AssertionError: from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why     hello          '[m + [31m'   there'[m; [35;1mprint[m(a); [33;1massert[m False
+    [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why     hello          "[m + [31m"   there"[m; [35;1mprint[m(a); [33;1massert[m False
+    [36m                       |                      |                  |                         |                                                 -> 'why     hello             there'[m
+    [36m                       |                      |                  |                         -> 'why     hello             there'[m
+    [36m                       |                      |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       |                      -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       -> _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)[m
+AssertionError: [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why     hello          "[m + [31m"   there"[m; [35;1mprint[m(a); [33;1massert[m False
 why     hello             there
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-    from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why     hello          '[m + [31m'   there'[m; [35;1mprint[m(a); [33;1massert[m False
-    [36m                                                                 |                         |                                                 -> 'why     hello             there'[m
-    [36m                                                                 |                         -> 'why     hello             there'[m
-    [36m                                                                 -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
-AssertionError: from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why     hello          '[m + [31m'   there'[m; [35;1mprint[m(a); [33;1massert[m False
+    [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why     hello          "[m + [31m"   there"[m; [35;1mprint[m(a); [33;1massert[m False
+    [36m                       |                      |                  |                         |                                                 -> 'why     hello             there'[m
+    [36m                       |                      |                  |                         -> 'why     hello             there'[m
+    [36m                       |                      |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       |                      -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       -> _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)[m
+AssertionError: [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why     hello          "[m + [31m"   there"[m; [35;1mprint[m(a); [33;1massert[m False
 why     hello             there
 
 
@@ -233,7 +243,7 @@ Traceback (most recent call last):
     [36m|     -> 1[m
     [36m-> <function cause at 0xDEADBEEF>[m
   File "test/test_chaining.py", line 13, in cause
-    [33;1mraise[m [35;1mValueError[m([31m'Division error'[m)
+    [33;1mraise[m [35;1mValueError[m([31m"Division error"[m)
 ValueError: Division error
 
 The above exception was the direct cause of the following exception:
@@ -243,7 +253,7 @@ Traceback (most recent call last):
     context([31m1[m, [31m0[m)
     [36m-> <function context at 0xDEADBEEF>[m
   File "test/test_chaining.py", line 19, in context
-    [33;1mraise[m [35;1mValueError[m([31m'Cause error'[m) from e
+    [33;1mraise[m [35;1mValueError[m([31m"Cause error"[m) [33;1mfrom[m e
 ValueError: Cause error
 
 
@@ -264,6 +274,35 @@ Traceback (most recent call last):
     [36m    [4, 5, 6][m
     [36m    [7, 8, 9]][m
 TypeError: unsupported operand type(s) for +: 'A' and 'A'
+
+
+
+python test/test_source_multilines.py
+
+
+Traceback (most recent call last):
+  File "test/test_source_multilines.py", line 16, in <module>
+    """)
+  File "test/test_source_multilines.py", line 13, in test
+    , string, [31m3[m)
+    [36m  -> 'multi-lines\n'[m
+  File "test/test_source_multilines.py", line 8, in add
+    [33;1mreturn[m (a + b + \
+    [36m        |   -> 'multi-lines\n'[m
+    [36m        -> 1[m
+TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+
+
+python test/test_source_strings.py
+
+
+Traceback (most recent call last):
+  File "test/test_source_strings.py", line 8, in <module>
+    a + [31mb"prefix"[m + [31m'single'[m + [31m"""triple"""[m + [31m1[m + b
+    [36m|                                             -> 0[m
+    [36m-> 0[m
+TypeError: unsupported operand type(s) for +: 'int' and 'bytes'
 
 
 

--- a/test/output/python-dumb-ascii-nocolor.out
+++ b/test/output/python-dumb-ascii-nocolor.out
@@ -73,17 +73,19 @@ import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this should work fine
-                              |                         |             -> 5
-                              |                         -> 5
-                              -> <module 'test_module' from '/removed/for/test/purposes.py'>
+           |                  |                         |             -> 5
+           |                  |                         -> 5
+           |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>
+           -> <module 'test_module' from '/removed/for/test/purposes.py'>
 AssertionError: import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this should work fine
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this should work fine
-                              |                         |             -> 5
-                              |                         -> 5
-                              -> <module 'test_module' from '/removed/for/test/purposes.py'>
+           |                  |                         |             -> 5
+           |                  |                         -> 5
+           |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>
+           -> <module 'test_module' from '/removed/for/test/purposes.py'>
 AssertionError: import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this should work fine
 
 from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
@@ -91,18 +93,22 @@ from __future__ import print_function; import better_exceptions; better_exceptio
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
-                                                                     |                         |                            -> 'why hello there'
-                                                                     |                         -> 'why hello there'
-                                                                     -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           |                      |                  |                         |                            -> 'why hello there'
+                           |                      |                  |                         -> 'why hello there'
+                           |                      |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           |                      -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           -> _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)
 AssertionError: from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
 why hello there
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
-                                                                     |                         |                            -> 'why hello there'
-                                                                     |                         -> 'why hello there'
-                                                                     -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           |                      |                  |                         |                            -> 'why hello there'
+                           |                      |                  |                         -> 'why hello there'
+                           |                      |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           |                      -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           -> _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)
 AssertionError: from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
 why hello there
 
@@ -111,18 +117,22 @@ from __future__ import print_function; import better_exceptions; better_exceptio
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
-                                                                     |                         |                                                 -> 'why     hello             there'
-                                                                     |                         -> 'why     hello             there'
-                                                                     -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           |                      |                  |                         |                                                 -> 'why     hello             there'
+                           |                      |                  |                         -> 'why     hello             there'
+                           |                      |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           |                      -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           -> _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)
 AssertionError: from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
 why     hello             there
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
-                                                                     |                         |                                                 -> 'why     hello             there'
-                                                                     |                         -> 'why     hello             there'
-                                                                     -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           |                      |                  |                         |                                                 -> 'why     hello             there'
+                           |                      |                  |                         -> 'why     hello             there'
+                           |                      |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           |                      -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           -> _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)
 AssertionError: from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
 why     hello             there
 
@@ -264,6 +274,35 @@ Traceback (most recent call last):
         [4, 5, 6]
         [7, 8, 9]]
 TypeError: unsupported operand type(s) for +: 'A' and 'A'
+
+
+
+python test/test_source_multilines.py
+
+
+Traceback (most recent call last):
+  File "test/test_source_multilines.py", line 16, in <module>
+    """)
+  File "test/test_source_multilines.py", line 13, in test
+    , string, 3)
+      -> 'multi-lines\n'
+  File "test/test_source_multilines.py", line 8, in add
+    return (a + b + \
+            |   -> 'multi-lines\n'
+            -> 1
+TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+
+
+python test/test_source_strings.py
+
+
+Traceback (most recent call last):
+  File "test/test_source_strings.py", line 8, in <module>
+    a + b"prefix" + 'single' + """triple""" + 1 + b
+    |                                             -> 0
+    -> 0
+TypeError: unsupported operand type(s) for +: 'int' and 'bytes'
 
 
 

--- a/test/output/python-vt100-UTF-8-color.out
+++ b/test/output/python-vt100-UTF-8-color.out
@@ -12,10 +12,10 @@ Traceback (most recent call last):
     [36m│    └ 2[m
     [36m└ <function deep at 0xDEADBEEF>[m
   File "test/test.py", line 13, in deep
-    [33;1massert[m val > [31m10[m and foo == [31m60[m
+    [33;1massert[m val > [31m10[m [33;1mand[m foo == [31m60[m
     [36m       │            └ 52[m
     [36m       └ 17[m
-AssertionError: [33;1massert[m val > [31m10[m and foo == [31m60[m
+AssertionError: [33;1massert[m val > [31m10[m [33;1mand[m foo == [31m60[m
 
 
 
@@ -34,7 +34,7 @@ Traceback (most recent call last):
     div()
     [36m└ <function div at 0xDEADBEEF>[m
   File "test/test_encoding.py", line 11, in div
-    [33;1mreturn[m _deep([31m'天'[m)
+    [33;1mreturn[m _deep([31m"天"[m)
     [36m       └ <function _deep at 0xDEADBEEF>[m
   File "test/test_encoding.py", line 8, in _deep
     [33;1mreturn[m [31m1[m / val
@@ -73,57 +73,67 @@ import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m5[m; [33;1massert[m a > [31m10[m [2;37m# this should work fine[m
-    [36m                          │                         │             └ 5[m
-    [36m                          │                         └ 5[m
-    [36m                          └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m       │                  │                         │             └ 5[m
+    [36m       │                  │                         └ 5[m
+    [36m       │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m       └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
 AssertionError: [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m5[m; [33;1massert[m a > [31m10[m [2;37m# this should work fine[m
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m5[m; [33;1massert[m a > [31m10[m [2;37m# this should work fine[m
-    [36m                          │                         │             └ 5[m
-    [36m                          │                         └ 5[m
-    [36m                          └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m       │                  │                         │             └ 5[m
+    [36m       │                  │                         └ 5[m
+    [36m       │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m       └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
 AssertionError: [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m5[m; [33;1massert[m a > [31m10[m [2;37m# this should work fine[m
 
 from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-    from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why hello there'[m; [35;1mprint[m(a); [33;1massert[m False
-    [36m                                                                 │                         │                            └ 'why hello there'[m
-    [36m                                                                 │                         └ 'why hello there'[m
-    [36m                                                                 └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
-AssertionError: from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why hello there'[m; [35;1mprint[m(a); [33;1massert[m False
+    [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why hello there"[m; [35;1mprint[m(a); [33;1massert[m False
+    [36m                       │                      │                  │                         │                            └ 'why hello there'[m
+    [36m                       │                      │                  │                         └ 'why hello there'[m
+    [36m                       │                      │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       │                      └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       └ _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)[m
+AssertionError: [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why hello there"[m; [35;1mprint[m(a); [33;1massert[m False
 why hello there
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-    from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why hello there'[m; [35;1mprint[m(a); [33;1massert[m False
-    [36m                                                                 │                         │                            └ 'why hello there'[m
-    [36m                                                                 │                         └ 'why hello there'[m
-    [36m                                                                 └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
-AssertionError: from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why hello there'[m; [35;1mprint[m(a); [33;1massert[m False
+    [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why hello there"[m; [35;1mprint[m(a); [33;1massert[m False
+    [36m                       │                      │                  │                         │                            └ 'why hello there'[m
+    [36m                       │                      │                  │                         └ 'why hello there'[m
+    [36m                       │                      │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       │                      └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       └ _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)[m
+AssertionError: [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why hello there"[m; [35;1mprint[m(a); [33;1massert[m False
 why hello there
 
 from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-    from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why     hello          '[m + [31m'   there'[m; [35;1mprint[m(a); [33;1massert[m False
-    [36m                                                                 │                         │                                                 └ 'why     hello             there'[m
-    [36m                                                                 │                         └ 'why     hello             there'[m
-    [36m                                                                 └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
-AssertionError: from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why     hello          '[m + [31m'   there'[m; [35;1mprint[m(a); [33;1massert[m False
+    [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why     hello          "[m + [31m"   there"[m; [35;1mprint[m(a); [33;1massert[m False
+    [36m                       │                      │                  │                         │                                                 └ 'why     hello             there'[m
+    [36m                       │                      │                  │                         └ 'why     hello             there'[m
+    [36m                       │                      │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       │                      └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       └ _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)[m
+AssertionError: [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why     hello          "[m + [31m"   there"[m; [35;1mprint[m(a); [33;1massert[m False
 why     hello             there
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-    from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why     hello          '[m + [31m'   there'[m; [35;1mprint[m(a); [33;1massert[m False
-    [36m                                                                 │                         │                                                 └ 'why     hello             there'[m
-    [36m                                                                 │                         └ 'why     hello             there'[m
-    [36m                                                                 └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
-AssertionError: from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why     hello          '[m + [31m'   there'[m; [35;1mprint[m(a); [33;1massert[m False
+    [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why     hello          "[m + [31m"   there"[m; [35;1mprint[m(a); [33;1massert[m False
+    [36m                       │                      │                  │                         │                                                 └ 'why     hello             there'[m
+    [36m                       │                      │                  │                         └ 'why     hello             there'[m
+    [36m                       │                      │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       │                      └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       └ _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)[m
+AssertionError: [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why     hello          "[m + [31m"   there"[m; [35;1mprint[m(a); [33;1massert[m False
 why     hello             there
 
 
@@ -233,7 +243,7 @@ Traceback (most recent call last):
     [36m│     └ 1[m
     [36m└ <function cause at 0xDEADBEEF>[m
   File "test/test_chaining.py", line 13, in cause
-    [33;1mraise[m [35;1mValueError[m([31m'Division error'[m)
+    [33;1mraise[m [35;1mValueError[m([31m"Division error"[m)
 ValueError: Division error
 
 The above exception was the direct cause of the following exception:
@@ -243,7 +253,7 @@ Traceback (most recent call last):
     context([31m1[m, [31m0[m)
     [36m└ <function context at 0xDEADBEEF>[m
   File "test/test_chaining.py", line 19, in context
-    [33;1mraise[m [35;1mValueError[m([31m'Cause error'[m) from e
+    [33;1mraise[m [35;1mValueError[m([31m"Cause error"[m) [33;1mfrom[m e
 ValueError: Cause error
 
 
@@ -264,6 +274,35 @@ Traceback (most recent call last):
     [36m   [4, 5, 6][m
     [36m   [7, 8, 9]][m
 TypeError: unsupported operand type(s) for +: 'A' and 'A'
+
+
+
+python test/test_source_multilines.py
+
+
+Traceback (most recent call last):
+  File "test/test_source_multilines.py", line 16, in <module>
+    """)
+  File "test/test_source_multilines.py", line 13, in test
+    , string, [31m3[m)
+    [36m  └ 'multi-lines\n'[m
+  File "test/test_source_multilines.py", line 8, in add
+    [33;1mreturn[m (a + b + \
+    [36m        │   └ 'multi-lines\n'[m
+    [36m        └ 1[m
+TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+
+
+python test/test_source_strings.py
+
+
+Traceback (most recent call last):
+  File "test/test_source_strings.py", line 8, in <module>
+    a + [31mb"prefix"[m + [31m'single'[m + [31m"""triple"""[m + [31m1[m + b
+    [36m│                                             └ 0[m
+    [36m└ 0[m
+TypeError: unsupported operand type(s) for +: 'int' and 'bytes'
 
 
 

--- a/test/output/python-vt100-UTF-8-nocolor.out
+++ b/test/output/python-vt100-UTF-8-nocolor.out
@@ -73,17 +73,19 @@ import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this should work fine
-                              │                         │             └ 5
-                              │                         └ 5
-                              └ <module 'test_module' from '/removed/for/test/purposes.py'>
+           │                  │                         │             └ 5
+           │                  │                         └ 5
+           │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>
+           └ <module 'test_module' from '/removed/for/test/purposes.py'>
 AssertionError: import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this should work fine
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this should work fine
-                              │                         │             └ 5
-                              │                         └ 5
-                              └ <module 'test_module' from '/removed/for/test/purposes.py'>
+           │                  │                         │             └ 5
+           │                  │                         └ 5
+           │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>
+           └ <module 'test_module' from '/removed/for/test/purposes.py'>
 AssertionError: import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this should work fine
 
 from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
@@ -91,18 +93,22 @@ from __future__ import print_function; import better_exceptions; better_exceptio
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
-                                                                     │                         │                            └ 'why hello there'
-                                                                     │                         └ 'why hello there'
-                                                                     └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           │                      │                  │                         │                            └ 'why hello there'
+                           │                      │                  │                         └ 'why hello there'
+                           │                      │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           │                      └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           └ _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)
 AssertionError: from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
 why hello there
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
-                                                                     │                         │                            └ 'why hello there'
-                                                                     │                         └ 'why hello there'
-                                                                     └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           │                      │                  │                         │                            └ 'why hello there'
+                           │                      │                  │                         └ 'why hello there'
+                           │                      │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           │                      └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           └ _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)
 AssertionError: from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
 why hello there
 
@@ -111,18 +117,22 @@ from __future__ import print_function; import better_exceptions; better_exceptio
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
-                                                                     │                         │                                                 └ 'why     hello             there'
-                                                                     │                         └ 'why     hello             there'
-                                                                     └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           │                      │                  │                         │                                                 └ 'why     hello             there'
+                           │                      │                  │                         └ 'why     hello             there'
+                           │                      │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           │                      └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           └ _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)
 AssertionError: from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
 why     hello             there
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
-                                                                     │                         │                                                 └ 'why     hello             there'
-                                                                     │                         └ 'why     hello             there'
-                                                                     └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           │                      │                  │                         │                                                 └ 'why     hello             there'
+                           │                      │                  │                         └ 'why     hello             there'
+                           │                      │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           │                      └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           └ _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)
 AssertionError: from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
 why     hello             there
 
@@ -264,6 +274,35 @@ Traceback (most recent call last):
        [4, 5, 6]
        [7, 8, 9]]
 TypeError: unsupported operand type(s) for +: 'A' and 'A'
+
+
+
+python test/test_source_multilines.py
+
+
+Traceback (most recent call last):
+  File "test/test_source_multilines.py", line 16, in <module>
+    """)
+  File "test/test_source_multilines.py", line 13, in test
+    , string, 3)
+      └ 'multi-lines\n'
+  File "test/test_source_multilines.py", line 8, in add
+    return (a + b + \
+            │   └ 'multi-lines\n'
+            └ 1
+TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+
+
+python test/test_source_strings.py
+
+
+Traceback (most recent call last):
+  File "test/test_source_strings.py", line 8, in <module>
+    a + b"prefix" + 'single' + """triple""" + 1 + b
+    │                                             └ 0
+    └ 0
+TypeError: unsupported operand type(s) for +: 'int' and 'bytes'
 
 
 

--- a/test/output/python-vt100-ascii-color.out
+++ b/test/output/python-vt100-ascii-color.out
@@ -12,10 +12,10 @@ Traceback (most recent call last):
     [36m|    -> 2[m
     [36m-> <function deep at 0xDEADBEEF>[m
   File "test/test.py", line 13, in deep
-    [33;1massert[m val > [31m10[m and foo == [31m60[m
+    [33;1massert[m val > [31m10[m [33;1mand[m foo == [31m60[m
     [36m       |            -> 52[m
     [36m       -> 17[m
-AssertionError: [33;1massert[m val > [31m10[m and foo == [31m60[m
+AssertionError: [33;1massert[m val > [31m10[m [33;1mand[m foo == [31m60[m
 
 
 
@@ -34,7 +34,7 @@ Traceback (most recent call last):
     div()
     [36m-> <function div at 0xDEADBEEF>[m
   File "test/test_encoding.py", line 11, in div
-    [33;1mreturn[m _deep([31m'天'[m)
+    [33;1mreturn[m _deep([31m"天"[m)
     [36m       -> <function _deep at 0xDEADBEEF>[m
   File "test/test_encoding.py", line 8, in _deep
     [33;1mreturn[m [31m1[m / val
@@ -73,57 +73,67 @@ import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m5[m; [33;1massert[m a > [31m10[m [2;37m# this should work fine[m
-    [36m                          |                         |             -> 5[m
-    [36m                          |                         -> 5[m
-    [36m                          -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m       |                  |                         |             -> 5[m
+    [36m       |                  |                         -> 5[m
+    [36m       |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m       -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
 AssertionError: [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m5[m; [33;1massert[m a > [31m10[m [2;37m# this should work fine[m
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m5[m; [33;1massert[m a > [31m10[m [2;37m# this should work fine[m
-    [36m                          |                         |             -> 5[m
-    [36m                          |                         -> 5[m
-    [36m                          -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m       |                  |                         |             -> 5[m
+    [36m       |                  |                         -> 5[m
+    [36m       |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m       -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
 AssertionError: [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m5[m; [33;1massert[m a > [31m10[m [2;37m# this should work fine[m
 
 from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-    from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why hello there'[m; [35;1mprint[m(a); [33;1massert[m False
-    [36m                                                                 |                         |                            -> 'why hello there'[m
-    [36m                                                                 |                         -> 'why hello there'[m
-    [36m                                                                 -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
-AssertionError: from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why hello there'[m; [35;1mprint[m(a); [33;1massert[m False
+    [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why hello there"[m; [35;1mprint[m(a); [33;1massert[m False
+    [36m                       |                      |                  |                         |                            -> 'why hello there'[m
+    [36m                       |                      |                  |                         -> 'why hello there'[m
+    [36m                       |                      |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       |                      -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       -> _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)[m
+AssertionError: [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why hello there"[m; [35;1mprint[m(a); [33;1massert[m False
 why hello there
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-    from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why hello there'[m; [35;1mprint[m(a); [33;1massert[m False
-    [36m                                                                 |                         |                            -> 'why hello there'[m
-    [36m                                                                 |                         -> 'why hello there'[m
-    [36m                                                                 -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
-AssertionError: from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why hello there'[m; [35;1mprint[m(a); [33;1massert[m False
+    [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why hello there"[m; [35;1mprint[m(a); [33;1massert[m False
+    [36m                       |                      |                  |                         |                            -> 'why hello there'[m
+    [36m                       |                      |                  |                         -> 'why hello there'[m
+    [36m                       |                      |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       |                      -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       -> _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)[m
+AssertionError: [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why hello there"[m; [35;1mprint[m(a); [33;1massert[m False
 why hello there
 
 from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-    from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why     hello          '[m + [31m'   there'[m; [35;1mprint[m(a); [33;1massert[m False
-    [36m                                                                 |                         |                                                 -> 'why     hello             there'[m
-    [36m                                                                 |                         -> 'why     hello             there'[m
-    [36m                                                                 -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
-AssertionError: from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why     hello          '[m + [31m'   there'[m; [35;1mprint[m(a); [33;1massert[m False
+    [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why     hello          "[m + [31m"   there"[m; [35;1mprint[m(a); [33;1massert[m False
+    [36m                       |                      |                  |                         |                                                 -> 'why     hello             there'[m
+    [36m                       |                      |                  |                         -> 'why     hello             there'[m
+    [36m                       |                      |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       |                      -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       -> _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)[m
+AssertionError: [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why     hello          "[m + [31m"   there"[m; [35;1mprint[m(a); [33;1massert[m False
 why     hello             there
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-    from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why     hello          '[m + [31m'   there'[m; [35;1mprint[m(a); [33;1massert[m False
-    [36m                                                                 |                         |                                                 -> 'why     hello             there'[m
-    [36m                                                                 |                         -> 'why     hello             there'[m
-    [36m                                                                 -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
-AssertionError: from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why     hello          '[m + [31m'   there'[m; [35;1mprint[m(a); [33;1massert[m False
+    [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why     hello          "[m + [31m"   there"[m; [35;1mprint[m(a); [33;1massert[m False
+    [36m                       |                      |                  |                         |                                                 -> 'why     hello             there'[m
+    [36m                       |                      |                  |                         -> 'why     hello             there'[m
+    [36m                       |                      |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       |                      -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       -> _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)[m
+AssertionError: [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why     hello          "[m + [31m"   there"[m; [35;1mprint[m(a); [33;1massert[m False
 why     hello             there
 
 
@@ -233,7 +243,7 @@ Traceback (most recent call last):
     [36m|     -> 1[m
     [36m-> <function cause at 0xDEADBEEF>[m
   File "test/test_chaining.py", line 13, in cause
-    [33;1mraise[m [35;1mValueError[m([31m'Division error'[m)
+    [33;1mraise[m [35;1mValueError[m([31m"Division error"[m)
 ValueError: Division error
 
 The above exception was the direct cause of the following exception:
@@ -243,7 +253,7 @@ Traceback (most recent call last):
     context([31m1[m, [31m0[m)
     [36m-> <function context at 0xDEADBEEF>[m
   File "test/test_chaining.py", line 19, in context
-    [33;1mraise[m [35;1mValueError[m([31m'Cause error'[m) from e
+    [33;1mraise[m [35;1mValueError[m([31m"Cause error"[m) [33;1mfrom[m e
 ValueError: Cause error
 
 
@@ -264,6 +274,35 @@ Traceback (most recent call last):
     [36m    [4, 5, 6][m
     [36m    [7, 8, 9]][m
 TypeError: unsupported operand type(s) for +: 'A' and 'A'
+
+
+
+python test/test_source_multilines.py
+
+
+Traceback (most recent call last):
+  File "test/test_source_multilines.py", line 16, in <module>
+    """)
+  File "test/test_source_multilines.py", line 13, in test
+    , string, [31m3[m)
+    [36m  -> 'multi-lines\n'[m
+  File "test/test_source_multilines.py", line 8, in add
+    [33;1mreturn[m (a + b + \
+    [36m        |   -> 'multi-lines\n'[m
+    [36m        -> 1[m
+TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+
+
+python test/test_source_strings.py
+
+
+Traceback (most recent call last):
+  File "test/test_source_strings.py", line 8, in <module>
+    a + [31mb"prefix"[m + [31m'single'[m + [31m"""triple"""[m + [31m1[m + b
+    [36m|                                             -> 0[m
+    [36m-> 0[m
+TypeError: unsupported operand type(s) for +: 'int' and 'bytes'
 
 
 

--- a/test/output/python-vt100-ascii-nocolor.out
+++ b/test/output/python-vt100-ascii-nocolor.out
@@ -73,17 +73,19 @@ import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this should work fine
-                              |                         |             -> 5
-                              |                         -> 5
-                              -> <module 'test_module' from '/removed/for/test/purposes.py'>
+           |                  |                         |             -> 5
+           |                  |                         -> 5
+           |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>
+           -> <module 'test_module' from '/removed/for/test/purposes.py'>
 AssertionError: import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this should work fine
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this should work fine
-                              |                         |             -> 5
-                              |                         -> 5
-                              -> <module 'test_module' from '/removed/for/test/purposes.py'>
+           |                  |                         |             -> 5
+           |                  |                         -> 5
+           |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>
+           -> <module 'test_module' from '/removed/for/test/purposes.py'>
 AssertionError: import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this should work fine
 
 from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
@@ -91,18 +93,22 @@ from __future__ import print_function; import better_exceptions; better_exceptio
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
-                                                                     |                         |                            -> 'why hello there'
-                                                                     |                         -> 'why hello there'
-                                                                     -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           |                      |                  |                         |                            -> 'why hello there'
+                           |                      |                  |                         -> 'why hello there'
+                           |                      |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           |                      -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           -> _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)
 AssertionError: from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
 why hello there
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
-                                                                     |                         |                            -> 'why hello there'
-                                                                     |                         -> 'why hello there'
-                                                                     -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           |                      |                  |                         |                            -> 'why hello there'
+                           |                      |                  |                         -> 'why hello there'
+                           |                      |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           |                      -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           -> _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)
 AssertionError: from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
 why hello there
 
@@ -111,18 +117,22 @@ from __future__ import print_function; import better_exceptions; better_exceptio
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
-                                                                     |                         |                                                 -> 'why     hello             there'
-                                                                     |                         -> 'why     hello             there'
-                                                                     -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           |                      |                  |                         |                                                 -> 'why     hello             there'
+                           |                      |                  |                         -> 'why     hello             there'
+                           |                      |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           |                      -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           -> _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)
 AssertionError: from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
 why     hello             there
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
-                                                                     |                         |                                                 -> 'why     hello             there'
-                                                                     |                         -> 'why     hello             there'
-                                                                     -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           |                      |                  |                         |                                                 -> 'why     hello             there'
+                           |                      |                  |                         -> 'why     hello             there'
+                           |                      |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           |                      -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           -> _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)
 AssertionError: from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
 why     hello             there
 
@@ -264,6 +274,35 @@ Traceback (most recent call last):
         [4, 5, 6]
         [7, 8, 9]]
 TypeError: unsupported operand type(s) for +: 'A' and 'A'
+
+
+
+python test/test_source_multilines.py
+
+
+Traceback (most recent call last):
+  File "test/test_source_multilines.py", line 16, in <module>
+    """)
+  File "test/test_source_multilines.py", line 13, in test
+    , string, 3)
+      -> 'multi-lines\n'
+  File "test/test_source_multilines.py", line 8, in add
+    return (a + b + \
+            |   -> 'multi-lines\n'
+            -> 1
+TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+
+
+python test/test_source_strings.py
+
+
+Traceback (most recent call last):
+  File "test/test_source_strings.py", line 8, in <module>
+    a + b"prefix" + 'single' + """triple""" + 1 + b
+    |                                             -> 0
+    -> 0
+TypeError: unsupported operand type(s) for +: 'int' and 'bytes'
 
 
 

--- a/test/output/python-xterm-UTF-8-color.out
+++ b/test/output/python-xterm-UTF-8-color.out
@@ -12,10 +12,10 @@ Traceback (most recent call last):
     [36m│    └ 2[m
     [36m└ <function deep at 0xDEADBEEF>[m
   File "test/test.py", line 13, in deep
-    [33;1massert[m val > [31m10[m and foo == [31m60[m
+    [33;1massert[m val > [31m10[m [33;1mand[m foo == [31m60[m
     [36m       │            └ 52[m
     [36m       └ 17[m
-AssertionError: [33;1massert[m val > [31m10[m and foo == [31m60[m
+AssertionError: [33;1massert[m val > [31m10[m [33;1mand[m foo == [31m60[m
 
 
 
@@ -34,7 +34,7 @@ Traceback (most recent call last):
     div()
     [36m└ <function div at 0xDEADBEEF>[m
   File "test/test_encoding.py", line 11, in div
-    [33;1mreturn[m _deep([31m'天'[m)
+    [33;1mreturn[m _deep([31m"天"[m)
     [36m       └ <function _deep at 0xDEADBEEF>[m
   File "test/test_encoding.py", line 8, in _deep
     [33;1mreturn[m [31m1[m / val
@@ -73,57 +73,67 @@ import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m5[m; [33;1massert[m a > [31m10[m [2;37m# this should work fine[m
-    [36m                          │                         │             └ 5[m
-    [36m                          │                         └ 5[m
-    [36m                          └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m       │                  │                         │             └ 5[m
+    [36m       │                  │                         └ 5[m
+    [36m       │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m       └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
 AssertionError: [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m5[m; [33;1massert[m a > [31m10[m [2;37m# this should work fine[m
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m5[m; [33;1massert[m a > [31m10[m [2;37m# this should work fine[m
-    [36m                          │                         │             └ 5[m
-    [36m                          │                         └ 5[m
-    [36m                          └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m       │                  │                         │             └ 5[m
+    [36m       │                  │                         └ 5[m
+    [36m       │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m       └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
 AssertionError: [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m5[m; [33;1massert[m a > [31m10[m [2;37m# this should work fine[m
 
 from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-    from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why hello there'[m; [35;1mprint[m(a); [33;1massert[m False
-    [36m                                                                 │                         │                            └ 'why hello there'[m
-    [36m                                                                 │                         └ 'why hello there'[m
-    [36m                                                                 └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
-AssertionError: from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why hello there'[m; [35;1mprint[m(a); [33;1massert[m False
+    [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why hello there"[m; [35;1mprint[m(a); [33;1massert[m False
+    [36m                       │                      │                  │                         │                            └ 'why hello there'[m
+    [36m                       │                      │                  │                         └ 'why hello there'[m
+    [36m                       │                      │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       │                      └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       └ _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)[m
+AssertionError: [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why hello there"[m; [35;1mprint[m(a); [33;1massert[m False
 why hello there
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-    from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why hello there'[m; [35;1mprint[m(a); [33;1massert[m False
-    [36m                                                                 │                         │                            └ 'why hello there'[m
-    [36m                                                                 │                         └ 'why hello there'[m
-    [36m                                                                 └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
-AssertionError: from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why hello there'[m; [35;1mprint[m(a); [33;1massert[m False
+    [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why hello there"[m; [35;1mprint[m(a); [33;1massert[m False
+    [36m                       │                      │                  │                         │                            └ 'why hello there'[m
+    [36m                       │                      │                  │                         └ 'why hello there'[m
+    [36m                       │                      │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       │                      └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       └ _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)[m
+AssertionError: [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why hello there"[m; [35;1mprint[m(a); [33;1massert[m False
 why hello there
 
 from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-    from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why     hello          '[m + [31m'   there'[m; [35;1mprint[m(a); [33;1massert[m False
-    [36m                                                                 │                         │                                                 └ 'why     hello             there'[m
-    [36m                                                                 │                         └ 'why     hello             there'[m
-    [36m                                                                 └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
-AssertionError: from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why     hello          '[m + [31m'   there'[m; [35;1mprint[m(a); [33;1massert[m False
+    [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why     hello          "[m + [31m"   there"[m; [35;1mprint[m(a); [33;1massert[m False
+    [36m                       │                      │                  │                         │                                                 └ 'why     hello             there'[m
+    [36m                       │                      │                  │                         └ 'why     hello             there'[m
+    [36m                       │                      │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       │                      └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       └ _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)[m
+AssertionError: [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why     hello          "[m + [31m"   there"[m; [35;1mprint[m(a); [33;1massert[m False
 why     hello             there
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-    from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why     hello          '[m + [31m'   there'[m; [35;1mprint[m(a); [33;1massert[m False
-    [36m                                                                 │                         │                                                 └ 'why     hello             there'[m
-    [36m                                                                 │                         └ 'why     hello             there'[m
-    [36m                                                                 └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
-AssertionError: from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why     hello          '[m + [31m'   there'[m; [35;1mprint[m(a); [33;1massert[m False
+    [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why     hello          "[m + [31m"   there"[m; [35;1mprint[m(a); [33;1massert[m False
+    [36m                       │                      │                  │                         │                                                 └ 'why     hello             there'[m
+    [36m                       │                      │                  │                         └ 'why     hello             there'[m
+    [36m                       │                      │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       │                      └ <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       └ _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)[m
+AssertionError: [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why     hello          "[m + [31m"   there"[m; [35;1mprint[m(a); [33;1massert[m False
 why     hello             there
 
 
@@ -233,7 +243,7 @@ Traceback (most recent call last):
     [36m│     └ 1[m
     [36m└ <function cause at 0xDEADBEEF>[m
   File "test/test_chaining.py", line 13, in cause
-    [33;1mraise[m [35;1mValueError[m([31m'Division error'[m)
+    [33;1mraise[m [35;1mValueError[m([31m"Division error"[m)
 ValueError: Division error
 
 The above exception was the direct cause of the following exception:
@@ -243,7 +253,7 @@ Traceback (most recent call last):
     context([31m1[m, [31m0[m)
     [36m└ <function context at 0xDEADBEEF>[m
   File "test/test_chaining.py", line 19, in context
-    [33;1mraise[m [35;1mValueError[m([31m'Cause error'[m) from e
+    [33;1mraise[m [35;1mValueError[m([31m"Cause error"[m) [33;1mfrom[m e
 ValueError: Cause error
 
 
@@ -264,6 +274,35 @@ Traceback (most recent call last):
     [36m   [4, 5, 6][m
     [36m   [7, 8, 9]][m
 TypeError: unsupported operand type(s) for +: 'A' and 'A'
+
+
+
+python test/test_source_multilines.py
+
+
+Traceback (most recent call last):
+  File "test/test_source_multilines.py", line 16, in <module>
+    """)
+  File "test/test_source_multilines.py", line 13, in test
+    , string, [31m3[m)
+    [36m  └ 'multi-lines\n'[m
+  File "test/test_source_multilines.py", line 8, in add
+    [33;1mreturn[m (a + b + \
+    [36m        │   └ 'multi-lines\n'[m
+    [36m        └ 1[m
+TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+
+
+python test/test_source_strings.py
+
+
+Traceback (most recent call last):
+  File "test/test_source_strings.py", line 8, in <module>
+    a + [31mb"prefix"[m + [31m'single'[m + [31m"""triple"""[m + [31m1[m + b
+    [36m│                                             └ 0[m
+    [36m└ 0[m
+TypeError: unsupported operand type(s) for +: 'int' and 'bytes'
 
 
 

--- a/test/output/python-xterm-UTF-8-nocolor.out
+++ b/test/output/python-xterm-UTF-8-nocolor.out
@@ -73,17 +73,19 @@ import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this should work fine
-                              │                         │             └ 5
-                              │                         └ 5
-                              └ <module 'test_module' from '/removed/for/test/purposes.py'>
+           │                  │                         │             └ 5
+           │                  │                         └ 5
+           │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>
+           └ <module 'test_module' from '/removed/for/test/purposes.py'>
 AssertionError: import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this should work fine
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this should work fine
-                              │                         │             └ 5
-                              │                         └ 5
-                              └ <module 'test_module' from '/removed/for/test/purposes.py'>
+           │                  │                         │             └ 5
+           │                  │                         └ 5
+           │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>
+           └ <module 'test_module' from '/removed/for/test/purposes.py'>
 AssertionError: import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this should work fine
 
 from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
@@ -91,18 +93,22 @@ from __future__ import print_function; import better_exceptions; better_exceptio
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
-                                                                     │                         │                            └ 'why hello there'
-                                                                     │                         └ 'why hello there'
-                                                                     └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           │                      │                  │                         │                            └ 'why hello there'
+                           │                      │                  │                         └ 'why hello there'
+                           │                      │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           │                      └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           └ _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)
 AssertionError: from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
 why hello there
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
-                                                                     │                         │                            └ 'why hello there'
-                                                                     │                         └ 'why hello there'
-                                                                     └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           │                      │                  │                         │                            └ 'why hello there'
+                           │                      │                  │                         └ 'why hello there'
+                           │                      │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           │                      └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           └ _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)
 AssertionError: from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
 why hello there
 
@@ -111,18 +117,22 @@ from __future__ import print_function; import better_exceptions; better_exceptio
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
-                                                                     │                         │                                                 └ 'why     hello             there'
-                                                                     │                         └ 'why     hello             there'
-                                                                     └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           │                      │                  │                         │                                                 └ 'why     hello             there'
+                           │                      │                  │                         └ 'why     hello             there'
+                           │                      │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           │                      └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           └ _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)
 AssertionError: from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
 why     hello             there
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
-                                                                     │                         │                                                 └ 'why     hello             there'
-                                                                     │                         └ 'why     hello             there'
-                                                                     └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           │                      │                  │                         │                                                 └ 'why     hello             there'
+                           │                      │                  │                         └ 'why     hello             there'
+                           │                      │                  └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           │                      └ <module 'test_module' from '/removed/for/test/purposes.py'>
+                           └ _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)
 AssertionError: from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
 why     hello             there
 
@@ -264,6 +274,35 @@ Traceback (most recent call last):
        [4, 5, 6]
        [7, 8, 9]]
 TypeError: unsupported operand type(s) for +: 'A' and 'A'
+
+
+
+python test/test_source_multilines.py
+
+
+Traceback (most recent call last):
+  File "test/test_source_multilines.py", line 16, in <module>
+    """)
+  File "test/test_source_multilines.py", line 13, in test
+    , string, 3)
+      └ 'multi-lines\n'
+  File "test/test_source_multilines.py", line 8, in add
+    return (a + b + \
+            │   └ 'multi-lines\n'
+            └ 1
+TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+
+
+python test/test_source_strings.py
+
+
+Traceback (most recent call last):
+  File "test/test_source_strings.py", line 8, in <module>
+    a + b"prefix" + 'single' + """triple""" + 1 + b
+    │                                             └ 0
+    └ 0
+TypeError: unsupported operand type(s) for +: 'int' and 'bytes'
 
 
 

--- a/test/output/python-xterm-ascii-color.out
+++ b/test/output/python-xterm-ascii-color.out
@@ -12,10 +12,10 @@ Traceback (most recent call last):
     [36m|    -> 2[m
     [36m-> <function deep at 0xDEADBEEF>[m
   File "test/test.py", line 13, in deep
-    [33;1massert[m val > [31m10[m and foo == [31m60[m
+    [33;1massert[m val > [31m10[m [33;1mand[m foo == [31m60[m
     [36m       |            -> 52[m
     [36m       -> 17[m
-AssertionError: [33;1massert[m val > [31m10[m and foo == [31m60[m
+AssertionError: [33;1massert[m val > [31m10[m [33;1mand[m foo == [31m60[m
 
 
 
@@ -34,7 +34,7 @@ Traceback (most recent call last):
     div()
     [36m-> <function div at 0xDEADBEEF>[m
   File "test/test_encoding.py", line 11, in div
-    [33;1mreturn[m _deep([31m'天'[m)
+    [33;1mreturn[m _deep([31m"天"[m)
     [36m       -> <function _deep at 0xDEADBEEF>[m
   File "test/test_encoding.py", line 8, in _deep
     [33;1mreturn[m [31m1[m / val
@@ -73,57 +73,67 @@ import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m5[m; [33;1massert[m a > [31m10[m [2;37m# this should work fine[m
-    [36m                          |                         |             -> 5[m
-    [36m                          |                         -> 5[m
-    [36m                          -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m       |                  |                         |             -> 5[m
+    [36m       |                  |                         -> 5[m
+    [36m       |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m       -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
 AssertionError: [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m5[m; [33;1massert[m a > [31m10[m [2;37m# this should work fine[m
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m5[m; [33;1massert[m a > [31m10[m [2;37m# this should work fine[m
-    [36m                          |                         |             -> 5[m
-    [36m                          |                         -> 5[m
-    [36m                          -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m       |                  |                         |             -> 5[m
+    [36m       |                  |                         -> 5[m
+    [36m       |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m       -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
 AssertionError: [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m5[m; [33;1massert[m a > [31m10[m [2;37m# this should work fine[m
 
 from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-    from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why hello there'[m; [35;1mprint[m(a); [33;1massert[m False
-    [36m                                                                 |                         |                            -> 'why hello there'[m
-    [36m                                                                 |                         -> 'why hello there'[m
-    [36m                                                                 -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
-AssertionError: from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why hello there'[m; [35;1mprint[m(a); [33;1massert[m False
+    [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why hello there"[m; [35;1mprint[m(a); [33;1massert[m False
+    [36m                       |                      |                  |                         |                            -> 'why hello there'[m
+    [36m                       |                      |                  |                         -> 'why hello there'[m
+    [36m                       |                      |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       |                      -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       -> _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)[m
+AssertionError: [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why hello there"[m; [35;1mprint[m(a); [33;1massert[m False
 why hello there
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-    from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why hello there'[m; [35;1mprint[m(a); [33;1massert[m False
-    [36m                                                                 |                         |                            -> 'why hello there'[m
-    [36m                                                                 |                         -> 'why hello there'[m
-    [36m                                                                 -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
-AssertionError: from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why hello there'[m; [35;1mprint[m(a); [33;1massert[m False
+    [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why hello there"[m; [35;1mprint[m(a); [33;1massert[m False
+    [36m                       |                      |                  |                         |                            -> 'why hello there'[m
+    [36m                       |                      |                  |                         -> 'why hello there'[m
+    [36m                       |                      |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       |                      -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       -> _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)[m
+AssertionError: [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why hello there"[m; [35;1mprint[m(a); [33;1massert[m False
 why hello there
 
 from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-    from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why     hello          '[m + [31m'   there'[m; [35;1mprint[m(a); [33;1massert[m False
-    [36m                                                                 |                         |                                                 -> 'why     hello             there'[m
-    [36m                                                                 |                         -> 'why     hello             there'[m
-    [36m                                                                 -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
-AssertionError: from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why     hello          '[m + [31m'   there'[m; [35;1mprint[m(a); [33;1massert[m False
+    [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why     hello          "[m + [31m"   there"[m; [35;1mprint[m(a); [33;1massert[m False
+    [36m                       |                      |                  |                         |                                                 -> 'why     hello             there'[m
+    [36m                       |                      |                  |                         -> 'why     hello             there'[m
+    [36m                       |                      |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       |                      -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       -> _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)[m
+AssertionError: [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why     hello          "[m + [31m"   there"[m; [35;1mprint[m(a); [33;1massert[m False
 why     hello             there
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
-    from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why     hello          '[m + [31m'   there'[m; [35;1mprint[m(a); [33;1massert[m False
-    [36m                                                                 |                         |                                                 -> 'why     hello             there'[m
-    [36m                                                                 |                         -> 'why     hello             there'[m
-    [36m                                                                 -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
-AssertionError: from __future__ import print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m'why     hello          '[m + [31m'   there'[m; [35;1mprint[m(a); [33;1massert[m False
+    [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why     hello          "[m + [31m"   there"[m; [35;1mprint[m(a); [33;1massert[m False
+    [36m                       |                      |                  |                         |                                                 -> 'why     hello             there'[m
+    [36m                       |                      |                  |                         -> 'why     hello             there'[m
+    [36m                       |                      |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       |                      -> <module 'test_module' from '/removed/for/test/purposes.py'>[m
+    [36m                       -> _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)[m
+AssertionError: [33;1mfrom[m __future__ [33;1mimport[m print_function; [33;1mimport[m better_exceptions; better_exceptions.hook(); a = [31m"why     hello          "[m + [31m"   there"[m; [35;1mprint[m(a); [33;1massert[m False
 why     hello             there
 
 
@@ -233,7 +243,7 @@ Traceback (most recent call last):
     [36m|     -> 1[m
     [36m-> <function cause at 0xDEADBEEF>[m
   File "test/test_chaining.py", line 13, in cause
-    [33;1mraise[m [35;1mValueError[m([31m'Division error'[m)
+    [33;1mraise[m [35;1mValueError[m([31m"Division error"[m)
 ValueError: Division error
 
 The above exception was the direct cause of the following exception:
@@ -243,7 +253,7 @@ Traceback (most recent call last):
     context([31m1[m, [31m0[m)
     [36m-> <function context at 0xDEADBEEF>[m
   File "test/test_chaining.py", line 19, in context
-    [33;1mraise[m [35;1mValueError[m([31m'Cause error'[m) from e
+    [33;1mraise[m [35;1mValueError[m([31m"Cause error"[m) [33;1mfrom[m e
 ValueError: Cause error
 
 
@@ -264,6 +274,35 @@ Traceback (most recent call last):
     [36m    [4, 5, 6][m
     [36m    [7, 8, 9]][m
 TypeError: unsupported operand type(s) for +: 'A' and 'A'
+
+
+
+python test/test_source_multilines.py
+
+
+Traceback (most recent call last):
+  File "test/test_source_multilines.py", line 16, in <module>
+    """)
+  File "test/test_source_multilines.py", line 13, in test
+    , string, [31m3[m)
+    [36m  -> 'multi-lines\n'[m
+  File "test/test_source_multilines.py", line 8, in add
+    [33;1mreturn[m (a + b + \
+    [36m        |   -> 'multi-lines\n'[m
+    [36m        -> 1[m
+TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+
+
+python test/test_source_strings.py
+
+
+Traceback (most recent call last):
+  File "test/test_source_strings.py", line 8, in <module>
+    a + [31mb"prefix"[m + [31m'single'[m + [31m"""triple"""[m + [31m1[m + b
+    [36m|                                             -> 0[m
+    [36m-> 0[m
+TypeError: unsupported operand type(s) for +: 'int' and 'bytes'
 
 
 

--- a/test/output/python-xterm-ascii-nocolor.out
+++ b/test/output/python-xterm-ascii-nocolor.out
@@ -73,17 +73,19 @@ import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this should work fine
-                              |                         |             -> 5
-                              |                         -> 5
-                              -> <module 'test_module' from '/removed/for/test/purposes.py'>
+           |                  |                         |             -> 5
+           |                  |                         -> 5
+           |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>
+           -> <module 'test_module' from '/removed/for/test/purposes.py'>
 AssertionError: import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this should work fine
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this should work fine
-                              |                         |             -> 5
-                              |                         -> 5
-                              -> <module 'test_module' from '/removed/for/test/purposes.py'>
+           |                  |                         |             -> 5
+           |                  |                         -> 5
+           |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>
+           -> <module 'test_module' from '/removed/for/test/purposes.py'>
 AssertionError: import better_exceptions; better_exceptions.hook(); a = 5; assert a > 10 # this should work fine
 
 from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
@@ -91,18 +93,22 @@ from __future__ import print_function; import better_exceptions; better_exceptio
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
-                                                                     |                         |                            -> 'why hello there'
-                                                                     |                         -> 'why hello there'
-                                                                     -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           |                      |                  |                         |                            -> 'why hello there'
+                           |                      |                  |                         -> 'why hello there'
+                           |                      |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           |                      -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           -> _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)
 AssertionError: from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
 why hello there
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
-                                                                     |                         |                            -> 'why hello there'
-                                                                     |                         -> 'why hello there'
-                                                                     -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           |                      |                  |                         |                            -> 'why hello there'
+                           |                      |                  |                         -> 'why hello there'
+                           |                      |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           |                      -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           -> _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)
 AssertionError: from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why hello there"; print(a); assert False
 why hello there
 
@@ -111,18 +117,22 @@ from __future__ import print_function; import better_exceptions; better_exceptio
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
-                                                                     |                         |                                                 -> 'why     hello             there'
-                                                                     |                         -> 'why     hello             there'
-                                                                     -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           |                      |                  |                         |                                                 -> 'why     hello             there'
+                           |                      |                  |                         -> 'why     hello             there'
+                           |                      |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           |                      -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           -> _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)
 AssertionError: from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
 why     hello             there
 
 Traceback (most recent call last):
   File "<string>", line 1, in <module>
     from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
-                                                                     |                         |                                                 -> 'why     hello             there'
-                                                                     |                         -> 'why     hello             there'
-                                                                     -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           |                      |                  |                         |                                                 -> 'why     hello             there'
+                           |                      |                  |                         -> 'why     hello             there'
+                           |                      |                  -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           |                      -> <module 'test_module' from '/removed/for/test/purposes.py'>
+                           -> _Feature((2, 6, 0, 'alpha', 2), (3, 0, 0, 'alpha', 0), 65536)
 AssertionError: from __future__ import print_function; import better_exceptions; better_exceptions.hook(); a = "why     hello          " + "   there"; print(a); assert False
 why     hello             there
 
@@ -264,6 +274,35 @@ Traceback (most recent call last):
         [4, 5, 6]
         [7, 8, 9]]
 TypeError: unsupported operand type(s) for +: 'A' and 'A'
+
+
+
+python test/test_source_multilines.py
+
+
+Traceback (most recent call last):
+  File "test/test_source_multilines.py", line 16, in <module>
+    """)
+  File "test/test_source_multilines.py", line 13, in test
+    , string, 3)
+      -> 'multi-lines\n'
+  File "test/test_source_multilines.py", line 8, in add
+    return (a + b + \
+            |   -> 'multi-lines\n'
+            -> 1
+TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+
+
+python test/test_source_strings.py
+
+
+Traceback (most recent call last):
+  File "test/test_source_strings.py", line 8, in <module>
+    a + b"prefix" + 'single' + """triple""" + 1 + b
+    |                                             -> 0
+    -> 0
+TypeError: unsupported operand type(s) for +: 'int' and 'bytes'
 
 
 

--- a/test/test_source_multilines.py
+++ b/test/test_source_multilines.py
@@ -1,0 +1,16 @@
+# -*- coding:utf-8 -*-
+
+import better_exceptions
+better_exceptions.hook()
+
+
+def add(a, b, c):
+    return (a + b + \
+            c)
+
+def test(string):
+    add(1
+        , string, 3)
+
+test("""multi-lines
+""")

--- a/test/test_source_strings.py
+++ b/test/test_source_strings.py
@@ -1,0 +1,8 @@
+# -*- coding:utf-8 -*-
+
+import better_exceptions
+better_exceptions.hook()
+
+
+a = b = 0
+a + b"prefix" + 'single' + """triple""" + 1 + b

--- a/test_all.sh
+++ b/test_all.sh
@@ -45,6 +45,8 @@ function test_all {
 	test_case "$BETEXC_PYTHON" "test/test_syntax_error.py"
 	test_case "$BETEXC_PYTHON" "test/test_chaining.py"
 	test_case "$BETEXC_PYTHON" "test/test_multilines_repr.py"
+	test_case "$BETEXC_PYTHON" "test/test_source_multilines.py"
+	test_case "$BETEXC_PYTHON" "test/test_source_strings.py"
 }
 
 for encoding in ascii "UTF-8"; do


### PR DESCRIPTION
Hello @Qix- 

Here is a suggestion to replace the parser ([`ast`](https://docs.python.org/3/library/ast.html)) with a lexer ([`tokenize`](https://docs.python.org/3/library/tokenize.html)).

This is required to fix some edge cases, because the parser doesn't have access to the source which generated the abstract syntax tree, so it failed to properly reconstruct the line of code. Also, I think a flatten list of tokens is easier to work with to implement #71. Note the new `THEME` variable that I think could be useful for #51. 

Also worth mentioning, [this very good documentation](https://www.asmeurer.com/brown-water-python/)  about Python tokenizer.

Tell me what you think of this. 🙂 

---

This code:

```python
a, b = 1, 0
dct = {
    "foo": 1,
    "bar": a / b,
}
```

Failed to show variables because the line is not valid expression:

```
Traceback (most recent call last):
  File "test.py", line 11, in <module>
    "bar": a / b,
ZeroDivisionError: division by zero
```

Using the lexer:

```
Traceback (most recent call last):
  File "test.py", line 11, in <module>
    "bar": a / b,
           │   └ 0
           └ 1
ZeroDivisionError: division by zero
```

---

Here is also a small problem with formatting, supposing this code:

```python
a = 1
a + b"prefix" + 'single' + """triple""" + 1
```

Weird things are happening:

```
Traceback (most recent call last):
  File "test.py", line 9, in <module>
    a + b"prefix" + 'single' + 'triple'e""" + 1
    └ 1
TypeError: unsupported operand type(s) for +: 'int' and 'bytes'
```

Using the lexer:

```
Traceback (most recent call last):
  File "test.py", line 9, in <module>
    a + b"prefix" + 'single' + """triple""" + 1
    └ 1
TypeError: unsupported operand type(s) for +: 'int' and 'bytes'
```