### PR TITLE
fix COMMENT_REGXP

### DIFF
--- a/better_exceptions/formatter.py
+++ b/better_exceptions/formatter.py
@@ -41,7 +41,7 @@ def isast(v):
 
 class ExceptionFormatter(object):
 
-    COMMENT_REGXP = re.compile(r'((?:(?:"(?:[^\\"]|(\\\\)*\\")*")|(?:\'(?:[^\\"]|(\\\\)*\\\')*\')|[^#])*)(#.*)$')
+    COMMENT_REGXP = re.compile(r'((?:(?:"(?:[^\\"]|(\\\\)*\\")*")|(?:\'(?:[^\\\']|(\\\\)*\\\')*\')|[^#])*)(#.*)?$')
     CMDLINE_REGXP = re.compile(r'(?:[^\t ]*([\'"])(?:\\.|.)*(?:\1))[^\t ]*|([^\t ]+)')
 
     AST_ELEMENTS = {

--- a/better_exceptions/formatter.py
+++ b/better_exceptions/formatter.py
@@ -41,7 +41,7 @@ def isast(v):
 
 class ExceptionFormatter(object):
 
-    COMMENT_REGXP = re.compile(r'((?:(?:"(?:[^\\"]|(\\\\)*\\")*")|(?:\'(?:[^\\\']|(\\\\)*\\\')*\')|[^#])*)(#.*)?$')
+    COMMENT_REGXP = re.compile(r'((?:(?:"(?:[^\\"]|(\\\\)*\\")*")|(?:\'(?:[^\\\']|(\\\\)*\\\')*\')|[^#])*)(#.*)$')
     CMDLINE_REGXP = re.compile(r'(?:[^\t ]*([\'"])(?:\\.|.)*(?:\1))[^\t ]*|([^\t ]+)')
 
     AST_ELEMENTS = {


### PR DESCRIPTION
i noticed a couple of bugs in the regular expression while testing.

the first bug is found when a line doesn't have a comment but has `#` in a string. the matcher seems to forcefully fetch the `#` from inside of the string. [proof](https://regex101.com/r/tUCeTa/1). to fix this i have made the comment optional.

the second bug was introduced because a `"` was put where a `'` should have been. this causes a `'` delimited string containing a `"` to be matched incorrectly. [proof](https://regex101.com/r/qlunxG/1). to fix this i have replaced the `"` with `\'`