### PR TITLE
Enable keyboard navigation in interactive repl by default

### DIFF
--- a/better_exceptions/__main__.py
+++ b/better_exceptions/__main__.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 
 try:
     import importlib.machinery
@@ -20,6 +21,8 @@ except ImportError:
 
 from better_exceptions import interact, hook
 hook()
+if sys.version_info[0] == 3:
+    sys.__interactivehook__()
 
 parser = argparse.ArgumentParser(description='A Python REPL with better exceptions enabled', prog='python -m better_exceptions')
 parser.add_argument('-q', '--quiet', help="don't show a banner", action='store_true')

--- a/better_exceptions/__main__.py
+++ b/better_exceptions/__main__.py
@@ -21,8 +21,11 @@ except ImportError:
 
 from better_exceptions import interact, hook
 hook()
+
+
 if sys.version_info[0] == 3:
     sys.__interactivehook__()
+
 
 parser = argparse.ArgumentParser(description='A Python REPL with better exceptions enabled', prog='python -m better_exceptions')
 parser.add_argument('-q', '--quiet', help="don't show a banner", action='store_true')


### PR DESCRIPTION
Call `sys.__interactivehook__` in Python 3 Repls to enable
keyboard navigation through previous commands 

This should fix #90

I'm not entirely sure if this is everything, but I tried this locally and the REPL was navigable with the up and down arrows. 
Also, this works for Python 3 only, since the `sys.__interactivehook__` function was added in Python 3

Feedback welcome!