### PR TITLE
Disable color flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ export BETTER_EXCEPTIONS=1  # Linux / OSX
 setx BETTER_EXCEPTIONS 1    # Windows
 ```
 
+To disable coloring, set the following environment variable:
+```bash
+export DISABLE_COLOR=True # Linux / OSX
+setx DISABLE_COLOR=True
+```
+
 That's it!
 
 ### Python REPL (Interactive Shell)

--- a/better_exceptions/color.py
+++ b/better_exceptions/color.py
@@ -19,7 +19,6 @@ STREAM = sys.stderr
 SHOULD_ENCODE = True
 SUPPORTS_COLOR = False
 
-
 def get_terminfo_file():
     term = os.getenv('TERM', None)
 
@@ -68,7 +67,6 @@ class ProxyBufferStreamWrapper(object):
         data = _byte(text)
         self.__wrapped.buffer.write(data)
 
-
 if os.name == 'nt':
     from colorama import init as init_colorama, AnsiToWin32
 
@@ -116,3 +114,6 @@ else:
 
                         if max_colors >= 8:
                             SUPPORTS_COLOR = True
+
+if os.getenv('DISABLE_COLOR', None) == "True":
+    SUPPORTS_COLOR = False


### PR DESCRIPTION
I'm a little unsure if this is what the issue here is cited: https://github.com/Qix-/better-exceptions/issues/51

But I believe this stops producing colorized output for my version of better-exceptions.