### PR TITLE
remove color from log files

### DIFF
--- a/better_exceptions/log.py
+++ b/better_exceptions/log.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import sys
 
-from logging import Logger, StreamHandler
+from logging import Logger, StreamHandler, FileHandler
 
 
 def patch():
@@ -14,7 +14,8 @@ def patch():
     if hasattr(logging, '_defaultFormatter'):
         logging._defaultFormatter.format_exception = logging_format_exception
 
-    patchables = [handler() for handler in logging._handlerList if isinstance(handler(), StreamHandler)]
+    patchables = [handler() for handler in logging._handlerList if isinstance(handler(), StreamHandler)
+                  if not isinstance(handler(), FileHandler)]
     patchables = [handler for handler in patchables if handler.stream == sys.stderr]
     patchables = [handler for handler in patchables if handler.formatter is not None]
     for handler in patchables:

--- a/test/output/python2-dumb-UTF-8-color.out
+++ b/test/output/python2-dumb-UTF-8-color.out
@@ -219,3 +219,32 @@ SyntaxError: invalid syntax
 
 
 
+python2 test/test_file_without_colors.py
+
+
+INFO:__main__:Hello
+INFO:__main__:Hello
+NoneType
+
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+    [36m└ <function bar3 at 0xDEADBEEF>[m
+  File "test/test_file_without_colors.py", line 36, in bar3
+    [33;1mraise[m [35;1mException[m([31m'this is a test exception'[m)
+Exception: this is a test exception
+
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+    [36m└ <function bar4 at 0xDEADBEEF>[m
+  File "test/test_file_without_colors.py", line 41, in bar4
+    [33;1massert[m baz == [31m90[m
+    [36m       └ 52[m
+AssertionError: [33;1massert[m baz == [31m90[m
+
+
+
+

--- a/test/output/python2-dumb-UTF-8-nocolor.out
+++ b/test/output/python2-dumb-UTF-8-nocolor.out
@@ -219,3 +219,32 @@ SyntaxError: invalid syntax
 
 
 
+python2 test/test_file_without_colors.py
+
+
+INFO:__main__:Hello
+INFO:__main__:Hello
+NoneType
+
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+    └ <function bar3 at 0xDEADBEEF>
+  File "test/test_file_without_colors.py", line 36, in bar3
+    raise Exception('this is a test exception')
+Exception: this is a test exception
+
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+    └ <function bar4 at 0xDEADBEEF>
+  File "test/test_file_without_colors.py", line 41, in bar4
+    assert baz == 90
+           └ 52
+AssertionError: assert baz == 90
+
+
+
+

--- a/test/output/python2-dumb-ascii-color.out
+++ b/test/output/python2-dumb-ascii-color.out
@@ -219,3 +219,32 @@ SyntaxError: invalid syntax
 
 
 
+python2 test/test_file_without_colors.py
+
+
+INFO:__main__:Hello
+INFO:__main__:Hello
+NoneType
+
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+    [36m-> <function bar3 at 0xDEADBEEF>[m
+  File "test/test_file_without_colors.py", line 36, in bar3
+    [33;1mraise[m [35;1mException[m([31m'this is a test exception'[m)
+Exception: this is a test exception
+
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+    [36m-> <function bar4 at 0xDEADBEEF>[m
+  File "test/test_file_without_colors.py", line 41, in bar4
+    [33;1massert[m baz == [31m90[m
+    [36m       -> 52[m
+AssertionError: [33;1massert[m baz == [31m90[m
+
+
+
+

--- a/test/output/python2-dumb-ascii-nocolor.out
+++ b/test/output/python2-dumb-ascii-nocolor.out
@@ -219,3 +219,32 @@ SyntaxError: invalid syntax
 
 
 
+python2 test/test_file_without_colors.py
+
+
+INFO:__main__:Hello
+INFO:__main__:Hello
+NoneType
+
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+    -> <function bar3 at 0xDEADBEEF>
+  File "test/test_file_without_colors.py", line 36, in bar3
+    raise Exception('this is a test exception')
+Exception: this is a test exception
+
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+    -> <function bar4 at 0xDEADBEEF>
+  File "test/test_file_without_colors.py", line 41, in bar4
+    assert baz == 90
+           -> 52
+AssertionError: assert baz == 90
+
+
+
+

--- a/test/output/python2-vt100-UTF-8-color.out
+++ b/test/output/python2-vt100-UTF-8-color.out
@@ -219,3 +219,32 @@ SyntaxError: invalid syntax
 
 
 
+python2 test/test_file_without_colors.py
+
+
+INFO:__main__:Hello
+INFO:__main__:Hello
+NoneType
+
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+    [36m└ <function bar3 at 0xDEADBEEF>[m
+  File "test/test_file_without_colors.py", line 36, in bar3
+    [33;1mraise[m [35;1mException[m([31m'this is a test exception'[m)
+Exception: this is a test exception
+
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+    [36m└ <function bar4 at 0xDEADBEEF>[m
+  File "test/test_file_without_colors.py", line 41, in bar4
+    [33;1massert[m baz == [31m90[m
+    [36m       └ 52[m
+AssertionError: [33;1massert[m baz == [31m90[m
+
+
+
+

--- a/test/output/python2-vt100-UTF-8-nocolor.out
+++ b/test/output/python2-vt100-UTF-8-nocolor.out
@@ -219,3 +219,32 @@ SyntaxError: invalid syntax
 
 
 
+python2 test/test_file_without_colors.py
+
+
+INFO:__main__:Hello
+INFO:__main__:Hello
+NoneType
+
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+    └ <function bar3 at 0xDEADBEEF>
+  File "test/test_file_without_colors.py", line 36, in bar3
+    raise Exception('this is a test exception')
+Exception: this is a test exception
+
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+    └ <function bar4 at 0xDEADBEEF>
+  File "test/test_file_without_colors.py", line 41, in bar4
+    assert baz == 90
+           └ 52
+AssertionError: assert baz == 90
+
+
+
+

--- a/test/output/python2-vt100-ascii-color.out
+++ b/test/output/python2-vt100-ascii-color.out
@@ -219,3 +219,32 @@ SyntaxError: invalid syntax
 
 
 
+python2 test/test_file_without_colors.py
+
+
+INFO:__main__:Hello
+INFO:__main__:Hello
+NoneType
+
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+    [36m-> <function bar3 at 0xDEADBEEF>[m
+  File "test/test_file_without_colors.py", line 36, in bar3
+    [33;1mraise[m [35;1mException[m([31m'this is a test exception'[m)
+Exception: this is a test exception
+
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+    [36m-> <function bar4 at 0xDEADBEEF>[m
+  File "test/test_file_without_colors.py", line 41, in bar4
+    [33;1massert[m baz == [31m90[m
+    [36m       -> 52[m
+AssertionError: [33;1massert[m baz == [31m90[m
+
+
+
+

--- a/test/output/python2-vt100-ascii-nocolor.out
+++ b/test/output/python2-vt100-ascii-nocolor.out
@@ -219,3 +219,32 @@ SyntaxError: invalid syntax
 
 
 
+python2 test/test_file_without_colors.py
+
+
+INFO:__main__:Hello
+INFO:__main__:Hello
+NoneType
+
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+    -> <function bar3 at 0xDEADBEEF>
+  File "test/test_file_without_colors.py", line 36, in bar3
+    raise Exception('this is a test exception')
+Exception: this is a test exception
+
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+    -> <function bar4 at 0xDEADBEEF>
+  File "test/test_file_without_colors.py", line 41, in bar4
+    assert baz == 90
+           -> 52
+AssertionError: assert baz == 90
+
+
+
+

--- a/test/output/python2-xterm-UTF-8-color.out
+++ b/test/output/python2-xterm-UTF-8-color.out
@@ -219,3 +219,32 @@ SyntaxError: invalid syntax
 
 
 
+python2 test/test_file_without_colors.py
+
+
+INFO:__main__:Hello
+INFO:__main__:Hello
+NoneType
+
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+    [36m└ <function bar3 at 0xDEADBEEF>[m
+  File "test/test_file_without_colors.py", line 36, in bar3
+    [33;1mraise[m [35;1mException[m([31m'this is a test exception'[m)
+Exception: this is a test exception
+
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+    [36m└ <function bar4 at 0xDEADBEEF>[m
+  File "test/test_file_without_colors.py", line 41, in bar4
+    [33;1massert[m baz == [31m90[m
+    [36m       └ 52[m
+AssertionError: [33;1massert[m baz == [31m90[m
+
+
+
+

--- a/test/output/python2-xterm-UTF-8-nocolor.out
+++ b/test/output/python2-xterm-UTF-8-nocolor.out
@@ -219,3 +219,32 @@ SyntaxError: invalid syntax
 
 
 
+python2 test/test_file_without_colors.py
+
+
+INFO:__main__:Hello
+INFO:__main__:Hello
+NoneType
+
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+    └ <function bar3 at 0xDEADBEEF>
+  File "test/test_file_without_colors.py", line 36, in bar3
+    raise Exception('this is a test exception')
+Exception: this is a test exception
+
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+    └ <function bar4 at 0xDEADBEEF>
+  File "test/test_file_without_colors.py", line 41, in bar4
+    assert baz == 90
+           └ 52
+AssertionError: assert baz == 90
+
+
+
+

--- a/test/output/python2-xterm-ascii-color.out
+++ b/test/output/python2-xterm-ascii-color.out
@@ -219,3 +219,32 @@ SyntaxError: invalid syntax
 
 
 
+python2 test/test_file_without_colors.py
+
+
+INFO:__main__:Hello
+INFO:__main__:Hello
+NoneType
+
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+    [36m-> <function bar3 at 0xDEADBEEF>[m
+  File "test/test_file_without_colors.py", line 36, in bar3
+    [33;1mraise[m [35;1mException[m([31m'this is a test exception'[m)
+Exception: this is a test exception
+
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+    [36m-> <function bar4 at 0xDEADBEEF>[m
+  File "test/test_file_without_colors.py", line 41, in bar4
+    [33;1massert[m baz == [31m90[m
+    [36m       -> 52[m
+AssertionError: [33;1massert[m baz == [31m90[m
+
+
+
+

--- a/test/output/python2-xterm-ascii-nocolor.out
+++ b/test/output/python2-xterm-ascii-nocolor.out
@@ -219,3 +219,32 @@ SyntaxError: invalid syntax
 
 
 
+python2 test/test_file_without_colors.py
+
+
+INFO:__main__:Hello
+INFO:__main__:Hello
+NoneType
+
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+    -> <function bar3 at 0xDEADBEEF>
+  File "test/test_file_without_colors.py", line 36, in bar3
+    raise Exception('this is a test exception')
+Exception: this is a test exception
+
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+    -> <function bar4 at 0xDEADBEEF>
+  File "test/test_file_without_colors.py", line 41, in bar4
+    assert baz == 90
+           -> 52
+AssertionError: assert baz == 90
+
+
+
+

--- a/test/output/python3-dumb-UTF-8-color.out
+++ b/test/output/python3-dumb-UTF-8-color.out
@@ -209,6 +209,29 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_file_without_colors.py
+
+
+INFO:__main__:Hello
+INFO:__main__:Hello
+NoneType: None
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+  File "test/test_file_without_colors.py", line 36, in bar3
+    raise Exception('this is a test exception')
+Exception: this is a test exception
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+  File "test/test_file_without_colors.py", line 41, in bar4
+    assert baz == 90
+AssertionError
+
+
+
 python3 test/test_chaining.py
 
 

--- a/test/output/python3-dumb-UTF-8-nocolor.out
+++ b/test/output/python3-dumb-UTF-8-nocolor.out
@@ -209,6 +209,29 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_file_without_colors.py
+
+
+INFO:__main__:Hello
+INFO:__main__:Hello
+NoneType: None
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+  File "test/test_file_without_colors.py", line 36, in bar3
+    raise Exception('this is a test exception')
+Exception: this is a test exception
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+  File "test/test_file_without_colors.py", line 41, in bar4
+    assert baz == 90
+AssertionError
+
+
+
 python3 test/test_chaining.py
 
 

--- a/test/output/python3-dumb-ascii-color.out
+++ b/test/output/python3-dumb-ascii-color.out
@@ -209,6 +209,29 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_file_without_colors.py
+
+
+INFO:__main__:Hello
+INFO:__main__:Hello
+NoneType: None
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+  File "test/test_file_without_colors.py", line 36, in bar3
+    raise Exception('this is a test exception')
+Exception: this is a test exception
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+  File "test/test_file_without_colors.py", line 41, in bar4
+    assert baz == 90
+AssertionError
+
+
+
 python3 test/test_chaining.py
 
 

--- a/test/output/python3-dumb-ascii-nocolor.out
+++ b/test/output/python3-dumb-ascii-nocolor.out
@@ -209,6 +209,29 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_file_without_colors.py
+
+
+INFO:__main__:Hello
+INFO:__main__:Hello
+NoneType: None
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+  File "test/test_file_without_colors.py", line 36, in bar3
+    raise Exception('this is a test exception')
+Exception: this is a test exception
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+  File "test/test_file_without_colors.py", line 41, in bar4
+    assert baz == 90
+AssertionError
+
+
+
 python3 test/test_chaining.py
 
 

--- a/test/output/python3-vt100-UTF-8-color.out
+++ b/test/output/python3-vt100-UTF-8-color.out
@@ -209,6 +209,29 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_file_without_colors.py
+
+
+INFO:__main__:Hello
+INFO:__main__:Hello
+NoneType: None
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+  File "test/test_file_without_colors.py", line 36, in bar3
+    raise Exception('this is a test exception')
+Exception: this is a test exception
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+  File "test/test_file_without_colors.py", line 41, in bar4
+    assert baz == 90
+AssertionError
+
+
+
 python3 test/test_chaining.py
 
 

--- a/test/output/python3-vt100-UTF-8-nocolor.out
+++ b/test/output/python3-vt100-UTF-8-nocolor.out
@@ -209,6 +209,29 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_file_without_colors.py
+
+
+INFO:__main__:Hello
+INFO:__main__:Hello
+NoneType: None
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+  File "test/test_file_without_colors.py", line 36, in bar3
+    raise Exception('this is a test exception')
+Exception: this is a test exception
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+  File "test/test_file_without_colors.py", line 41, in bar4
+    assert baz == 90
+AssertionError
+
+
+
 python3 test/test_chaining.py
 
 

--- a/test/output/python3-vt100-ascii-color.out
+++ b/test/output/python3-vt100-ascii-color.out
@@ -209,6 +209,29 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_file_without_colors.py
+
+
+INFO:__main__:Hello
+INFO:__main__:Hello
+NoneType: None
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+  File "test/test_file_without_colors.py", line 36, in bar3
+    raise Exception('this is a test exception')
+Exception: this is a test exception
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+  File "test/test_file_without_colors.py", line 41, in bar4
+    assert baz == 90
+AssertionError
+
+
+
 python3 test/test_chaining.py
 
 

--- a/test/output/python3-vt100-ascii-nocolor.out
+++ b/test/output/python3-vt100-ascii-nocolor.out
@@ -209,6 +209,29 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_file_without_colors.py
+
+
+INFO:__main__:Hello
+INFO:__main__:Hello
+NoneType: None
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+  File "test/test_file_without_colors.py", line 36, in bar3
+    raise Exception('this is a test exception')
+Exception: this is a test exception
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+  File "test/test_file_without_colors.py", line 41, in bar4
+    assert baz == 90
+AssertionError
+
+
+
 python3 test/test_chaining.py
 
 

--- a/test/output/python3-xterm-UTF-8-color.out
+++ b/test/output/python3-xterm-UTF-8-color.out
@@ -209,6 +209,29 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_file_without_colors.py
+
+
+INFO:__main__:Hello
+INFO:__main__:Hello
+NoneType: None
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+  File "test/test_file_without_colors.py", line 36, in bar3
+    raise Exception('this is a test exception')
+Exception: this is a test exception
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+  File "test/test_file_without_colors.py", line 41, in bar4
+    assert baz == 90
+AssertionError
+
+
+
 python3 test/test_chaining.py
 
 

--- a/test/output/python3-xterm-UTF-8-nocolor.out
+++ b/test/output/python3-xterm-UTF-8-nocolor.out
@@ -209,6 +209,29 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_file_without_colors.py
+
+
+INFO:__main__:Hello
+INFO:__main__:Hello
+NoneType: None
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+  File "test/test_file_without_colors.py", line 36, in bar3
+    raise Exception('this is a test exception')
+Exception: this is a test exception
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+  File "test/test_file_without_colors.py", line 41, in bar4
+    assert baz == 90
+AssertionError
+
+
+
 python3 test/test_chaining.py
 
 

--- a/test/output/python3-xterm-ascii-color.out
+++ b/test/output/python3-xterm-ascii-color.out
@@ -209,6 +209,29 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_file_without_colors.py
+
+
+INFO:__main__:Hello
+INFO:__main__:Hello
+NoneType: None
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+  File "test/test_file_without_colors.py", line 36, in bar3
+    raise Exception('this is a test exception')
+Exception: this is a test exception
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+  File "test/test_file_without_colors.py", line 41, in bar4
+    assert baz == 90
+AssertionError
+
+
+
 python3 test/test_chaining.py
 
 

--- a/test/output/python3-xterm-ascii-nocolor.out
+++ b/test/output/python3-xterm-ascii-nocolor.out
@@ -209,6 +209,29 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_file_without_colors.py
+
+
+INFO:__main__:Hello
+INFO:__main__:Hello
+NoneType: None
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+  File "test/test_file_without_colors.py", line 36, in bar3
+    raise Exception('this is a test exception')
+Exception: this is a test exception
+ERROR:__main__:callback failed
+Traceback (most recent call last):
+  File "test/test_file_without_colors.py", line 19, in foo
+    cb()
+  File "test/test_file_without_colors.py", line 41, in bar4
+    assert baz == 90
+AssertionError
+
+
+
 python3 test/test_chaining.py
 
 

--- a/test/test_file_without_colors.py
+++ b/test/test_file_without_colors.py
@@ -1,0 +1,50 @@
+import better_exceptions
+import logging
+
+better_exceptions.hook()
+logging.basicConfig(filename='example.log', level=logging.DEBUG)
+
+logger = logging.getLogger(__name__)
+
+logging.raiseExceptions = True
+
+qux = 15
+
+def foo(cb):
+    qix = 20
+    try:
+        cb()
+    except:
+        logger.exception('callback failed')
+
+
+def bar1():
+    baz = 80.5
+    logger.info('Hello')
+
+
+def bar2():
+    baz = 890.50
+    logger.info('Hello', exc_info=True)
+
+
+def bar3():
+    baz = 600.524
+    raise Exception('this is a test exception')
+
+
+def bar4():
+    baz = 52
+    assert baz == 90
+
+
+FNS = [
+    bar1,
+    bar2,
+    bar3,
+    bar4
+]
+
+
+for fn in FNS:
+    foo(fn)

--- a/test/test_file_without_colors.py
+++ b/test/test_file_without_colors.py
@@ -1,8 +1,11 @@
 import better_exceptions
 import logging
+import sys
 
 better_exceptions.hook()
-logging.basicConfig(filename='example.log', level=logging.DEBUG)
+file_handler = logging.FileHandler(filename='example.log')
+stream_handler = logging.StreamHandler(sys.stdout)
+logging.basicConfig(level=logging.DEBUG, handlers=[file_handler, stream_handler])
 
 logger = logging.getLogger(__name__)
 

--- a/test_all.sh
+++ b/test_all.sh
@@ -43,6 +43,7 @@ function test_all {
 	test_case "$BETEXC_PYTHON" "test/test_truncating_disabled.py"
 	test_case "$BETEXC_PYTHON" "test/test_indentation_error.py"
 	test_case "$BETEXC_PYTHON" "test/test_syntax_error.py"
+	test_case "$BETEXC_PYTHON" "test/test_file_without_colors.py"
 
 	if [[ "$BETEXC_PYTHON" == "python3" ]]; then
 		test_case "$BETEXC_PYTHON" "test/test_chaining.py"


### PR DESCRIPTION
This PR removes the color from logfiles while keeping them if they are outputted to the console. This is done by additionally filtering for `FileHandlers` during the hook call.

I also added a new test that explicitly creates a log file. The file doesn't contain any ANSI codes after the test has run.

I am not sure if the output has to be re-generated. Best would be if you could take a look before merging it. If they do need ot re-generate, let me know. I'll add them in a new commit.

Closes #87.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#87: Logged exceptions shouldn't contain colour](https://issuehunt.io/repos/84720080/issues/87)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->