### PR TITLE
Only run `ps -ww -p $PID -o command=` if ps executable is available

### DIFF
--- a/better_exceptions/formatter.py
+++ b/better_exceptions/formatter.py
@@ -161,11 +161,16 @@ class ExceptionFormatter(object):
             pass
 
         if cmdline is None and os.name == 'posix':
-            from subprocess import CalledProcessError, check_output as spawn
+            from shutil import which
 
-            try:
-                cmdline = spawn(['ps', '-ww', '-p', str(os.getpid()), '-o', 'command='])
-            except CalledProcessError:
+            if which('ps'):
+                from subprocess import CalledProcessError, check_output as spawn
+
+                try:
+                    cmdline = spawn(['ps', '-ww', '-p', str(os.getpid()), '-o', 'command='])
+                except CalledProcessError:
+                    return ''
+            else:
                 return ''
         else:
             # current system doesn't have a way to get the command line


### PR DESCRIPTION
currently, this is what errors with better-exceptions look like when `ps` is not available:
```
Error in sys.excepthook:
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/better_exceptions/formatter.py", line 161, in get_string_source
    cmdline = spawn(['ps', '-ww', '-p', str(os.getpid()), '-o', 'command='])
  File "/usr/local/lib/python3.8/subprocess.py", line 411, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/local/lib/python3.8/subprocess.py", line 489, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/local/lib/python3.8/subprocess.py", line 854, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/local/lib/python3.8/subprocess.py", line 1702, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'ps'

Original exception was:
Traceback (most recent call last):
...
```