### PR TITLE
Py314

### DIFF
--- a/better_exceptions/formatter.py
+++ b/better_exceptions/formatter.py
@@ -282,7 +282,12 @@ class ExceptionFormatter(object):
 
             tb = tb.tb_next
 
-        lines = traceback.format_list(frames)
+        # Format frames manually instead of using traceback.format_list()
+        # Python 3.13+ changed format_list() to only show the first line of multiline text
+        lines = []
+        for filename, lineno, name, text in frames:
+            lines.append('  File "{}", line {}, in {}\n'.format(filename, lineno, name))
+            lines.append('    {}\n'.format(text))
 
         return ''.join(lines), final_source
 

--- a/better_exceptions/formatter.py
+++ b/better_exceptions/formatter.py
@@ -94,11 +94,19 @@ class ExceptionFormatter(object):
             if nodecls == ast.Name and node.id in self.AST_ELEMENTS['builtins']:
                 displayed_nodes.append((node, node.id, 'builtin'))
 
-            if nodecls == ast.Str:
+            # Old-style AST - removed in python 3.14
+            if hasattr(ast, "Str") and nodecls == ast.Str:
                 displayed_nodes.append((node, "'{}'".format(node.s), 'literal'))
 
-            if nodecls == ast.Num:
+            if hasattr(ast, "Num") and nodecls == ast.Num:
                 displayed_nodes.append((node, str(node.n), 'literal'))
+
+            # New-style since, used since python 3.8
+            if hasattr(ast, "Constant") and nodecls == ast.Constant:
+                if isinstance(node.value, str):
+                    displayed_nodes.append((node, "'{}'".format(node.value), 'literal'))
+                else:
+                    displayed_nodes.append((node, str(node.value), 'literal'))
 
         displayed_nodes.sort(key=lambda elem: elem[0].col_offset)
 


### PR DESCRIPTION
Resolves #135 

Python 3.14 dropped the old-style ast nodes

Since python 3.8, `ast.Constant` was used for both string and non-string constants [docs](https://docs.python.org/3/library/ast.html#ast.AST)

So I think we did not have constant highlighting working since 3.8.

Fixed to work with both old-style and new-style ast. Tested on py3.6 and 3.14:
```py
import better_exceptions
better_exceptions.hook()

def f(x):
    return x/0

def g(s: str):
    return f(int(s))

g("123")
```

3.6:
<img width="1233" height="339" alt="image" src="https://github.com/user-attachments/assets/8139b47d-50fc-4afe-abed-0abc1a9bf222" />

3.14:
<img width="1300" height="356" alt="image" src="https://github.com/user-attachments/assets/b50c921c-d0d7-44cb-9722-a67d04ac2ce6" />
