### PR TITLE
Build system, CI and fixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,51 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y expect
+          pip install -e .
+      - name: Run tests
+        run: ./test_all.sh
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for trusted publishing
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+      - name: Build package
+        run: python -m build
+      - name: Publish to Test PyPI
+        if: contains(github.ref, '-test')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+      - name: Publish to PyPI
+        if: "!contains(github.ref, '-test')"
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,13 +29,10 @@ jobs:
           uses: actions/setup-python@v6
           with:
               python-version: ${{ matrix.python-version }}
-        - name: Install dependencies (Linux)
+        - name: Install expect (Linux only)
           if: runner.os == 'Linux'
-          run: |
-            sudo apt-get install -y expect
-            pip install -e .
-        - name: Install dependencies (Windows/macOS)
-          if: runner.os != 'Linux'
+          run: sudo apt-get install -y expect
+        - name: Install package
           run: pip install -e .
         - name: Run tests
           run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,8 +1,6 @@
 name: Build and Lint
 on:
   push:
-    branches:
-    - master
   pull_request:
 
 jobs:
@@ -12,6 +10,18 @@ jobs:
           matrix:
             os: [ubuntu-latest, windows-latest, macos-latest]
             python-version: ["3.7", "3.12", "3.x"]  # 3.x = latest stable
+            exclude:
+              # Python 3.7 not available on ubuntu-latest (24.04) and macos-latest (14)
+              - os: ubuntu-latest
+                python-version: "3.7"
+              - os: macos-latest
+                python-version: "3.7"
+            include:
+              # Test Python 3.7 on older OS versions that support it
+              - os: ubuntu-22.04
+                python-version: "3.7"
+              - os: macos-13
+                python-version: "3.7"
           fail-fast: false
         steps:
         - uses: actions/checkout@v2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,21 +7,26 @@ on:
 
 jobs:
     test:
-        runs-on: ubuntu-latest
+        runs-on: ${{ matrix.os }}
         strategy:
           matrix:
-            python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+            os: [ubuntu-latest, windows-latest, macos-latest]
+            python-version: ["3.7", "3.12", "3.x"]  # 3.x = latest stable
           fail-fast: false
         steps:
         - uses: actions/checkout@v2
         - name: Set up Python
           uses: actions/setup-python@v6
           with:
-              python-version: ${{matrix.python-version}}
-        - name: Install dependencies
+              python-version: ${{ matrix.python-version }}
+        - name: Install dependencies (Linux)
+          if: runner.os == 'Linux'
           run: |
             sudo apt-get install -y expect
             pip install -e .
+        - name: Install dependencies (Windows/macOS)
+          if: runner.os != 'Linux'
+          run: pip install -e .
         - name: Run tests
           run: |
             ./test_all.sh

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,8 +20,8 @@ jobs:
               # Test Python 3.7 on older OS versions that support it
               - os: ubuntu-22.04
                 python-version: "3.7"
-              - os: macos-13
-                python-version: "3.7"
+              # Skip Python 3.7 on macOS - not available on ARM64 runners
+              # and older Intel runners (macos-12, macos-13) have issues
           fail-fast: false
         steps:
         - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -50,14 +50,11 @@ While using `better_exceptions` in production, do not forget to unset the `BETTE
 If you want to use `better_exceptions` to format `unittest`'s exception output, you can use the monkey patch below:
 
 ```python
-import sys
 import unittest
 import better_exceptions
 
 def patch(self, err, test):
     lines = better_exceptions.format_exception(*err)
-    if sys.version_info[0] == 2:
-        return u"".join(lines).encode("utf-8")
     return "".join(lines)
 
 unittest.result.TestResult._exc_info_to_string = patch

--- a/better_exceptions/formatter.py
+++ b/better_exceptions/formatter.py
@@ -108,6 +108,9 @@ class ExceptionFormatter(object):
                     displayed_nodes.append((node, "'{}'".format(node.s), 'literal'))
                 if hasattr(ast, "Num") and nodecls == ast.Num:
                     displayed_nodes.append((node, str(node.n), 'literal'))
+                # Python 3.7 uses NameConstant for True/False/None
+                if hasattr(ast, "NameConstant") and nodecls == ast.NameConstant:
+                    displayed_nodes.append((node, str(node.value), 'literal'))
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,52 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "better_exceptions-xl0"
+dynamic = ["version"]
+description = "Pretty and helpful exceptions, automatically"
+readme = "README.md"
+license = {text = "MIT"}
+authors = [
+    {name = "Josh Junon", email = "pypi@josh.junon.me"}
+]
+keywords = [
+    "pretty",
+    "better",
+    "exceptions",
+    "exception",
+    "error",
+    "local",
+    "debug",
+    "debugging",
+    "locals"
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Debuggers",
+]
+requires-python = ">=3.7"
+dependencies = [
+    "colorama; sys_platform == 'win32'"
+]
+
+[project.urls]
+Homepage = "https://github.com/qix-/better-exceptions"
+Repository = "https://github.com/qix-/better-exceptions"
+Download = "https://github.com/qix-/better-exceptions/releases"
+
+[tool.setuptools]
+packages = ["better_exceptions", "better_exceptions.integrations"]
+
+[tool.setuptools.dynamic]
+version = {attr = "better_exceptions.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "better_exceptions-xl0"
+name = "better_exceptions"
 dynamic = ["version"]
 description = "Pretty and helpful exceptions, automatically"
 readme = "README.md"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,7 @@
-import re
-from itertools import chain
-from os.path import basename
-from os.path import dirname
-from os.path import join
-from os.path import splitext
-from distutils.core import setup
-from distutils.command.build import build
-from setuptools.command.develop import develop
-from setuptools.command.easy_install import easy_install
-from setuptools.command.install_lib import install_lib
+"""Setup script for better_exceptions - handles .pth file installation"""
+from os.path import basename, dirname, join
+from setuptools import setup
+from setuptools.command.build import build
 
 
 class BuildWithPTH(build):
@@ -19,59 +12,9 @@ class BuildWithPTH(build):
         self.copy_file(path, dest)
 
 
-class EasyInstallWithPTH(easy_install):
-    def run(self):
-        easy_install.run(self)
-        path = join(dirname(__file__), 'better_exceptions_hook.pth')
-        dest = join(self.install_dir, basename(path))
-        self.copy_file(path, dest)
-
-
-class InstallLibWithPTH(install_lib):
-    def run(self):
-        install_lib.run(self)
-        path = join(dirname(__file__), 'better_exceptions_hook.pth')
-        dest = join(self.install_dir, basename(path))
-        self.copy_file(path, dest)
-        self.outputs = [dest]
-
-    def get_outputs(self):
-        return chain(install_lib.get_outputs(self), self.outputs)
-
-
-class DevelopWithPTH(develop):
-    def run(self):
-        develop.run(self)
-        path = join(dirname(__file__), 'better_exceptions_hook.pth')
-        dest = join(self.install_dir, basename(path))
-        self.copy_file(path, dest)
-
-
-with open('better_exceptions/__init__.py', 'r') as file:
-    version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
-                        file.read(), re.MULTILINE).group(1)
-
+# Metadata is in pyproject.toml, this only handles .pth installation
 setup(
-    name = 'better_exceptions',
-    packages = ['better_exceptions', 'better_exceptions.integrations'],
-    version = version,
-    description = 'Pretty and helpful exceptions, automatically',
-    author = 'Josh Junon',
-    author_email = 'pypi@josh.junon.me',
-    url = 'https://github.com/qix-/better-exceptions',
-    download_url = 'https://github.com/qix-/better-exceptions/archive/{}.tar.gz'.format(version),
-    license = 'MIT',
-    keywords = ['pretty', 'better', 'exceptions', 'exception', 'error', 'local', 'debug', 'debugging', 'locals'],
-    classifiers = [],
-    extras_require = {
-        ':sys_platform=="win32"': ['colorama']
-    },
-    # This all comes from pytest-cov repository:
-    # https://github.com/pytest-dev/pytest-cov/blob/cde7c378b6a1971957759f42ac91e2860b41cf89/setup.py
-    cmdclass = {
+    cmdclass={
         'build': BuildWithPTH,
-        'easy_install': EasyInstallWithPTH,
-        'install_lib': InstallLibWithPTH,
-        'develop': DevelopWithPTH,
     }
 )

--- a/test/output/python3-dumb-UTF-8-color.out
+++ b/test/output/python3-dumb-UTF-8-color.out
@@ -208,3 +208,58 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_unittest_patch.py
+
+
+
+  File "/removed/for/test/purposes.ext", line 15, in test_add
+    self.assertEqual(add([31m1[m, [31m'2'[m), [31m3[m)
+    [36m│                └ <function add at 0xDEADBEEF>[m
+    [36m└ <__main__.MyTestCase testMethod=test_add>[m
+  File "/removed/for/test/purposes.ext", line 10, in add
+    [33;1mreturn[m a + b
+    [36m       │   └ '2'[m
+    [36m       └ 1[m
+TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+
+
+python3 test/test_chaining.py
+
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 11, in cause
+    div(x, y)
+    [36m│   │  └ 0[m
+    [36m│   └ 1[m
+    [36m└ <function div at 0xDEADBEEF>[m
+  File "/removed/for/test/purposes.ext", line 7, in div
+    x / y
+    [36m│   └ 0[m
+    [36m└ 1[m
+ZeroDivisionError: division by zero
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 17, in context
+    cause(x, y)
+    [36m│     │  └ 0[m
+    [36m│     └ 1[m
+    [36m└ <function cause at 0xDEADBEEF>[m
+  File "/removed/for/test/purposes.ext", line 13, in cause
+    [33;1mraise[m [35;1mValueError[m([31m'Division error'[m)
+ValueError: Division error
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 21, in <module>
+    context([31m1[m, [31m0[m)
+    [36m└ <function context at 0xDEADBEEF>[m
+  File "/removed/for/test/purposes.ext", line 19, in context
+    [33;1mraise[m [35;1mValueError[m([31m'Cause error'[m) from e
+ValueError: Cause error
+
+
+

--- a/test/output/python3-dumb-UTF-8-nocolor.out
+++ b/test/output/python3-dumb-UTF-8-nocolor.out
@@ -208,3 +208,58 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_unittest_patch.py
+
+
+
+  File "/removed/for/test/purposes.ext", line 15, in test_add
+    self.assertEqual(add(1, "2"), 3)
+    │                └ <function add at 0xDEADBEEF>
+    └ <__main__.MyTestCase testMethod=test_add>
+  File "/removed/for/test/purposes.ext", line 10, in add
+    return a + b
+           │   └ '2'
+           └ 1
+TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+
+
+python3 test/test_chaining.py
+
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 11, in cause
+    div(x, y)
+    │   │  └ 0
+    │   └ 1
+    └ <function div at 0xDEADBEEF>
+  File "/removed/for/test/purposes.ext", line 7, in div
+    x / y
+    │   └ 0
+    └ 1
+ZeroDivisionError: division by zero
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 17, in context
+    cause(x, y)
+    │     │  └ 0
+    │     └ 1
+    └ <function cause at 0xDEADBEEF>
+  File "/removed/for/test/purposes.ext", line 13, in cause
+    raise ValueError("Division error")
+ValueError: Division error
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 21, in <module>
+    context(1, 0)
+    └ <function context at 0xDEADBEEF>
+  File "/removed/for/test/purposes.ext", line 19, in context
+    raise ValueError("Cause error") from e
+ValueError: Cause error
+
+
+

--- a/test/output/python3-dumb-ascii-color.out
+++ b/test/output/python3-dumb-ascii-color.out
@@ -208,3 +208,58 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_unittest_patch.py
+
+
+
+  File "/removed/for/test/purposes.ext", line 15, in test_add
+    self.assertEqual(add([31m1[m, [31m'2'[m), [31m3[m)
+    [36m|                -> <function add at 0xDEADBEEF>[m
+    [36m-> <__main__.MyTestCase testMethod=test_add>[m
+  File "/removed/for/test/purposes.ext", line 10, in add
+    [33;1mreturn[m a + b
+    [36m       |   -> '2'[m
+    [36m       -> 1[m
+TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+
+
+python3 test/test_chaining.py
+
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 11, in cause
+    div(x, y)
+    [36m|   |  -> 0[m
+    [36m|   -> 1[m
+    [36m-> <function div at 0xDEADBEEF>[m
+  File "/removed/for/test/purposes.ext", line 7, in div
+    x / y
+    [36m|   -> 0[m
+    [36m-> 1[m
+ZeroDivisionError: division by zero
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 17, in context
+    cause(x, y)
+    [36m|     |  -> 0[m
+    [36m|     -> 1[m
+    [36m-> <function cause at 0xDEADBEEF>[m
+  File "/removed/for/test/purposes.ext", line 13, in cause
+    [33;1mraise[m [35;1mValueError[m([31m'Division error'[m)
+ValueError: Division error
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 21, in <module>
+    context([31m1[m, [31m0[m)
+    [36m-> <function context at 0xDEADBEEF>[m
+  File "/removed/for/test/purposes.ext", line 19, in context
+    [33;1mraise[m [35;1mValueError[m([31m'Cause error'[m) from e
+ValueError: Cause error
+
+
+

--- a/test/output/python3-dumb-ascii-nocolor.out
+++ b/test/output/python3-dumb-ascii-nocolor.out
@@ -208,3 +208,58 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_unittest_patch.py
+
+
+
+  File "/removed/for/test/purposes.ext", line 15, in test_add
+    self.assertEqual(add(1, "2"), 3)
+    |                -> <function add at 0xDEADBEEF>
+    -> <__main__.MyTestCase testMethod=test_add>
+  File "/removed/for/test/purposes.ext", line 10, in add
+    return a + b
+           |   -> '2'
+           -> 1
+TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+
+
+python3 test/test_chaining.py
+
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 11, in cause
+    div(x, y)
+    |   |  -> 0
+    |   -> 1
+    -> <function div at 0xDEADBEEF>
+  File "/removed/for/test/purposes.ext", line 7, in div
+    x / y
+    |   -> 0
+    -> 1
+ZeroDivisionError: division by zero
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 17, in context
+    cause(x, y)
+    |     |  -> 0
+    |     -> 1
+    -> <function cause at 0xDEADBEEF>
+  File "/removed/for/test/purposes.ext", line 13, in cause
+    raise ValueError("Division error")
+ValueError: Division error
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 21, in <module>
+    context(1, 0)
+    -> <function context at 0xDEADBEEF>
+  File "/removed/for/test/purposes.ext", line 19, in context
+    raise ValueError("Cause error") from e
+ValueError: Cause error
+
+
+

--- a/test/output/python3-vt100-UTF-8-color.out
+++ b/test/output/python3-vt100-UTF-8-color.out
@@ -208,3 +208,58 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_unittest_patch.py
+
+
+
+  File "/removed/for/test/purposes.ext", line 15, in test_add
+    self.assertEqual(add([31m1[m, [31m'2'[m), [31m3[m)
+    [36m│                └ <function add at 0xDEADBEEF>[m
+    [36m└ <__main__.MyTestCase testMethod=test_add>[m
+  File "/removed/for/test/purposes.ext", line 10, in add
+    [33;1mreturn[m a + b
+    [36m       │   └ '2'[m
+    [36m       └ 1[m
+TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+
+
+python3 test/test_chaining.py
+
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 11, in cause
+    div(x, y)
+    [36m│   │  └ 0[m
+    [36m│   └ 1[m
+    [36m└ <function div at 0xDEADBEEF>[m
+  File "/removed/for/test/purposes.ext", line 7, in div
+    x / y
+    [36m│   └ 0[m
+    [36m└ 1[m
+ZeroDivisionError: division by zero
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 17, in context
+    cause(x, y)
+    [36m│     │  └ 0[m
+    [36m│     └ 1[m
+    [36m└ <function cause at 0xDEADBEEF>[m
+  File "/removed/for/test/purposes.ext", line 13, in cause
+    [33;1mraise[m [35;1mValueError[m([31m'Division error'[m)
+ValueError: Division error
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 21, in <module>
+    context([31m1[m, [31m0[m)
+    [36m└ <function context at 0xDEADBEEF>[m
+  File "/removed/for/test/purposes.ext", line 19, in context
+    [33;1mraise[m [35;1mValueError[m([31m'Cause error'[m) from e
+ValueError: Cause error
+
+
+

--- a/test/output/python3-vt100-UTF-8-nocolor.out
+++ b/test/output/python3-vt100-UTF-8-nocolor.out
@@ -208,3 +208,58 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_unittest_patch.py
+
+
+
+  File "/removed/for/test/purposes.ext", line 15, in test_add
+    self.assertEqual(add(1, "2"), 3)
+    │                └ <function add at 0xDEADBEEF>
+    └ <__main__.MyTestCase testMethod=test_add>
+  File "/removed/for/test/purposes.ext", line 10, in add
+    return a + b
+           │   └ '2'
+           └ 1
+TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+
+
+python3 test/test_chaining.py
+
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 11, in cause
+    div(x, y)
+    │   │  └ 0
+    │   └ 1
+    └ <function div at 0xDEADBEEF>
+  File "/removed/for/test/purposes.ext", line 7, in div
+    x / y
+    │   └ 0
+    └ 1
+ZeroDivisionError: division by zero
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 17, in context
+    cause(x, y)
+    │     │  └ 0
+    │     └ 1
+    └ <function cause at 0xDEADBEEF>
+  File "/removed/for/test/purposes.ext", line 13, in cause
+    raise ValueError("Division error")
+ValueError: Division error
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 21, in <module>
+    context(1, 0)
+    └ <function context at 0xDEADBEEF>
+  File "/removed/for/test/purposes.ext", line 19, in context
+    raise ValueError("Cause error") from e
+ValueError: Cause error
+
+
+

--- a/test/output/python3-vt100-ascii-color.out
+++ b/test/output/python3-vt100-ascii-color.out
@@ -208,3 +208,58 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_unittest_patch.py
+
+
+
+  File "/removed/for/test/purposes.ext", line 15, in test_add
+    self.assertEqual(add([31m1[m, [31m'2'[m), [31m3[m)
+    [36m|                -> <function add at 0xDEADBEEF>[m
+    [36m-> <__main__.MyTestCase testMethod=test_add>[m
+  File "/removed/for/test/purposes.ext", line 10, in add
+    [33;1mreturn[m a + b
+    [36m       |   -> '2'[m
+    [36m       -> 1[m
+TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+
+
+python3 test/test_chaining.py
+
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 11, in cause
+    div(x, y)
+    [36m|   |  -> 0[m
+    [36m|   -> 1[m
+    [36m-> <function div at 0xDEADBEEF>[m
+  File "/removed/for/test/purposes.ext", line 7, in div
+    x / y
+    [36m|   -> 0[m
+    [36m-> 1[m
+ZeroDivisionError: division by zero
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 17, in context
+    cause(x, y)
+    [36m|     |  -> 0[m
+    [36m|     -> 1[m
+    [36m-> <function cause at 0xDEADBEEF>[m
+  File "/removed/for/test/purposes.ext", line 13, in cause
+    [33;1mraise[m [35;1mValueError[m([31m'Division error'[m)
+ValueError: Division error
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 21, in <module>
+    context([31m1[m, [31m0[m)
+    [36m-> <function context at 0xDEADBEEF>[m
+  File "/removed/for/test/purposes.ext", line 19, in context
+    [33;1mraise[m [35;1mValueError[m([31m'Cause error'[m) from e
+ValueError: Cause error
+
+
+

--- a/test/output/python3-vt100-ascii-nocolor.out
+++ b/test/output/python3-vt100-ascii-nocolor.out
@@ -208,3 +208,58 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_unittest_patch.py
+
+
+
+  File "/removed/for/test/purposes.ext", line 15, in test_add
+    self.assertEqual(add(1, "2"), 3)
+    |                -> <function add at 0xDEADBEEF>
+    -> <__main__.MyTestCase testMethod=test_add>
+  File "/removed/for/test/purposes.ext", line 10, in add
+    return a + b
+           |   -> '2'
+           -> 1
+TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+
+
+python3 test/test_chaining.py
+
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 11, in cause
+    div(x, y)
+    |   |  -> 0
+    |   -> 1
+    -> <function div at 0xDEADBEEF>
+  File "/removed/for/test/purposes.ext", line 7, in div
+    x / y
+    |   -> 0
+    -> 1
+ZeroDivisionError: division by zero
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 17, in context
+    cause(x, y)
+    |     |  -> 0
+    |     -> 1
+    -> <function cause at 0xDEADBEEF>
+  File "/removed/for/test/purposes.ext", line 13, in cause
+    raise ValueError("Division error")
+ValueError: Division error
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 21, in <module>
+    context(1, 0)
+    -> <function context at 0xDEADBEEF>
+  File "/removed/for/test/purposes.ext", line 19, in context
+    raise ValueError("Cause error") from e
+ValueError: Cause error
+
+
+

--- a/test/output/python3-xterm-UTF-8-color.out
+++ b/test/output/python3-xterm-UTF-8-color.out
@@ -208,3 +208,58 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_unittest_patch.py
+
+
+
+  File "/removed/for/test/purposes.ext", line 15, in test_add
+    self.assertEqual(add([31m1[m, [31m'2'[m), [31m3[m)
+    [36m│                └ <function add at 0xDEADBEEF>[m
+    [36m└ <__main__.MyTestCase testMethod=test_add>[m
+  File "/removed/for/test/purposes.ext", line 10, in add
+    [33;1mreturn[m a + b
+    [36m       │   └ '2'[m
+    [36m       └ 1[m
+TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+
+
+python3 test/test_chaining.py
+
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 11, in cause
+    div(x, y)
+    [36m│   │  └ 0[m
+    [36m│   └ 1[m
+    [36m└ <function div at 0xDEADBEEF>[m
+  File "/removed/for/test/purposes.ext", line 7, in div
+    x / y
+    [36m│   └ 0[m
+    [36m└ 1[m
+ZeroDivisionError: division by zero
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 17, in context
+    cause(x, y)
+    [36m│     │  └ 0[m
+    [36m│     └ 1[m
+    [36m└ <function cause at 0xDEADBEEF>[m
+  File "/removed/for/test/purposes.ext", line 13, in cause
+    [33;1mraise[m [35;1mValueError[m([31m'Division error'[m)
+ValueError: Division error
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 21, in <module>
+    context([31m1[m, [31m0[m)
+    [36m└ <function context at 0xDEADBEEF>[m
+  File "/removed/for/test/purposes.ext", line 19, in context
+    [33;1mraise[m [35;1mValueError[m([31m'Cause error'[m) from e
+ValueError: Cause error
+
+
+

--- a/test/output/python3-xterm-UTF-8-nocolor.out
+++ b/test/output/python3-xterm-UTF-8-nocolor.out
@@ -208,3 +208,58 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_unittest_patch.py
+
+
+
+  File "/removed/for/test/purposes.ext", line 15, in test_add
+    self.assertEqual(add(1, "2"), 3)
+    │                └ <function add at 0xDEADBEEF>
+    └ <__main__.MyTestCase testMethod=test_add>
+  File "/removed/for/test/purposes.ext", line 10, in add
+    return a + b
+           │   └ '2'
+           └ 1
+TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+
+
+python3 test/test_chaining.py
+
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 11, in cause
+    div(x, y)
+    │   │  └ 0
+    │   └ 1
+    └ <function div at 0xDEADBEEF>
+  File "/removed/for/test/purposes.ext", line 7, in div
+    x / y
+    │   └ 0
+    └ 1
+ZeroDivisionError: division by zero
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 17, in context
+    cause(x, y)
+    │     │  └ 0
+    │     └ 1
+    └ <function cause at 0xDEADBEEF>
+  File "/removed/for/test/purposes.ext", line 13, in cause
+    raise ValueError("Division error")
+ValueError: Division error
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 21, in <module>
+    context(1, 0)
+    └ <function context at 0xDEADBEEF>
+  File "/removed/for/test/purposes.ext", line 19, in context
+    raise ValueError("Cause error") from e
+ValueError: Cause error
+
+
+

--- a/test/output/python3-xterm-ascii-color.out
+++ b/test/output/python3-xterm-ascii-color.out
@@ -208,3 +208,58 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_unittest_patch.py
+
+
+
+  File "/removed/for/test/purposes.ext", line 15, in test_add
+    self.assertEqual(add([31m1[m, [31m'2'[m), [31m3[m)
+    [36m|                -> <function add at 0xDEADBEEF>[m
+    [36m-> <__main__.MyTestCase testMethod=test_add>[m
+  File "/removed/for/test/purposes.ext", line 10, in add
+    [33;1mreturn[m a + b
+    [36m       |   -> '2'[m
+    [36m       -> 1[m
+TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+
+
+python3 test/test_chaining.py
+
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 11, in cause
+    div(x, y)
+    [36m|   |  -> 0[m
+    [36m|   -> 1[m
+    [36m-> <function div at 0xDEADBEEF>[m
+  File "/removed/for/test/purposes.ext", line 7, in div
+    x / y
+    [36m|   -> 0[m
+    [36m-> 1[m
+ZeroDivisionError: division by zero
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 17, in context
+    cause(x, y)
+    [36m|     |  -> 0[m
+    [36m|     -> 1[m
+    [36m-> <function cause at 0xDEADBEEF>[m
+  File "/removed/for/test/purposes.ext", line 13, in cause
+    [33;1mraise[m [35;1mValueError[m([31m'Division error'[m)
+ValueError: Division error
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 21, in <module>
+    context([31m1[m, [31m0[m)
+    [36m-> <function context at 0xDEADBEEF>[m
+  File "/removed/for/test/purposes.ext", line 19, in context
+    [33;1mraise[m [35;1mValueError[m([31m'Cause error'[m) from e
+ValueError: Cause error
+
+
+

--- a/test/output/python3-xterm-ascii-nocolor.out
+++ b/test/output/python3-xterm-ascii-nocolor.out
@@ -208,3 +208,58 @@ SyntaxError: invalid syntax
 
 
 
+python3 test/test_unittest_patch.py
+
+
+
+  File "/removed/for/test/purposes.ext", line 15, in test_add
+    self.assertEqual(add(1, "2"), 3)
+    |                -> <function add at 0xDEADBEEF>
+    -> <__main__.MyTestCase testMethod=test_add>
+  File "/removed/for/test/purposes.ext", line 10, in add
+    return a + b
+           |   -> '2'
+           -> 1
+TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+
+
+python3 test/test_chaining.py
+
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 11, in cause
+    div(x, y)
+    |   |  -> 0
+    |   -> 1
+    -> <function div at 0xDEADBEEF>
+  File "/removed/for/test/purposes.ext", line 7, in div
+    x / y
+    |   -> 0
+    -> 1
+ZeroDivisionError: division by zero
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 17, in context
+    cause(x, y)
+    |     |  -> 0
+    |     -> 1
+    -> <function cause at 0xDEADBEEF>
+  File "/removed/for/test/purposes.ext", line 13, in cause
+    raise ValueError("Division error")
+ValueError: Division error
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/removed/for/test/purposes.ext", line 21, in <module>
+    context(1, 0)
+    -> <function context at 0xDEADBEEF>
+  File "/removed/for/test/purposes.ext", line 19, in context
+    raise ValueError("Cause error") from e
+ValueError: Cause error
+
+
+

--- a/test/test_unittest_patch.py
+++ b/test/test_unittest_patch.py
@@ -34,7 +34,22 @@ def print_test_error():
     # a test which raised an unexpected exception."
     assert isinstance(error, str)
     lines = error.splitlines()
-    print("\n".join(lines[4:]))  # remove '/removed/for/test/purposes.py'
+
+    # Filter out version-specific differences
+    # Skip everything until we hit the actual test frame (test_add)
+    # This avoids unittest internal differences between Python versions
+    filtered_lines = []
+    in_test_frame = False
+    for line in lines[4:]:  # remove '/removed/for/test/purposes.py'
+        # Start including lines once we hit the test frame
+        # there is some diff between py versions.
+        if 'in test_add' in line:
+            in_test_frame = True
+
+        if in_test_frame:
+            filtered_lines.append(line)
+
+    print("\n".join(filtered_lines))
 
 
 def main():
@@ -42,10 +57,7 @@ def main():
 
     def patch(self, err, test):
         lines = better_exceptions.format_exception(*err)
-        if sys.version_info[0] == 2:
-            return u"".join(lines).encode("utf-8")
-        else:
-            return u"".join(lines)
+        return u"".join(lines)
 
     unittest.result.TestResult._exc_info_to_string = patch
 

--- a/test/test_unittest_patch.py
+++ b/test/test_unittest_patch.py
@@ -1,9 +1,9 @@
 import io
-import sys
 import unittest
 import better_exceptions
 
-STREAM = io.BytesIO() if sys.version_info[0] == 2 else io.StringIO()
+
+STREAM = io.StringIO()
 
 
 def add(a, b):


### PR DESCRIPTION
- Update the build system
- CI tests on mac and win, reduced the number of versions we test
- Fix unit test test, chaining just works
- Publish workflow:
  - Push a tag - publishes to pypy
  - If tag has `-test` in it, publishes to test.pypi
 - Fix AST to work with all python version, highlight named constants (True, False, None) on legacy.
 - Remove leftover python 2 checks.
