### PR TITLE
fix: strip ANSI colors from logged exceptions

### DIFF
--- a/better_exceptions/log.py
+++ b/better_exceptions/log.py
@@ -7,9 +7,14 @@ from logging import Logger, StreamHandler
 
 def patch():
     import logging
-    from . import format_exception
+    from .formatter import ExceptionFormatter, THEME, MAX_LENGTH, PIPE_CHAR, CAP_CHAR
 
-    logging_format_exception = lambda exc_info: u''.join(format_exception(*exc_info))
+    def logging_format_exception(exc_info):
+        formatter = ExceptionFormatter(
+            colored=False, theme=THEME, max_length=MAX_LENGTH,
+            pipe_char=PIPE_CHAR, cap_char=CAP_CHAR
+        )
+        return u''.join(formatter.format_exception(*exc_info))
 
     if hasattr(logging, '_defaultFormatter'):
         logging._defaultFormatter.format_exception = logging_format_exception

--- a/better_exceptions/log.py
+++ b/better_exceptions/log.py
@@ -1,29 +1,36 @@
 from __future__ import absolute_import
 
+import logging
 import sys
 
 from logging import Logger, StreamHandler
 
 
-def patch():
-    import logging
+def _uncolored_format_exception(exc_info):
+    """Format exception without ANSI color codes."""
     from .formatter import ExceptionFormatter, THEME, MAX_LENGTH, PIPE_CHAR, CAP_CHAR
 
-    def logging_format_exception(exc_info):
-        formatter = ExceptionFormatter(
-            colored=False, theme=THEME, max_length=MAX_LENGTH,
-            pipe_char=PIPE_CHAR, cap_char=CAP_CHAR
-        )
-        return u''.join(formatter.format_exception(*exc_info))
+    formatter = ExceptionFormatter(
+        colored=False, theme=THEME, max_length=MAX_LENGTH,
+        pipe_char=PIPE_CHAR, cap_char=CAP_CHAR
+    )
+    return u''.join(formatter.format_exception(*exc_info))
 
-    if hasattr(logging, '_defaultFormatter'):
-        logging._defaultFormatter.format_exception = logging_format_exception
 
-    patchables = [handler() for handler in logging._handlerList if isinstance(handler(), StreamHandler)]
-    patchables = [handler for handler in patchables if handler.stream == sys.stderr]
-    patchables = [handler for handler in patchables if handler.formatter is not None]
-    for handler in patchables:
-        handler.formatter.formatException = logging_format_exception
+def patch():
+    from . import format_exception
+
+    colored_fn = lambda exc_info: u''.join(format_exception(*exc_info))
+
+    for handler_ref in logging._handlerList:
+        handler = handler_ref()
+        if handler is None or handler.formatter is None:
+            continue
+
+        if isinstance(handler, StreamHandler) and handler.stream is sys.stderr:
+            handler.formatter.formatException = colored_fn
+        else:
+            handler.formatter.formatException = _uncolored_format_exception
 
 
 class BetExcLogger(Logger):

--- a/test/test_file_logging.py
+++ b/test/test_file_logging.py
@@ -1,0 +1,59 @@
+"""Test that file logs are uncolored but stderr keeps colors."""
+import io
+import logging
+import os
+import re
+import sys
+import tempfile
+
+import better_exceptions
+
+ANSI_ESCAPE = re.compile(r'\x1b\[[0-9;]*m')
+
+def main():
+    better_exceptions.SUPPORTS_COLOR = True
+    better_exceptions.hook()
+
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+
+    original_stderr = sys.stderr
+    terminal = io.StringIO()
+    root = logging.getLogger()
+
+    try:
+        sys.stderr = terminal
+        file_handler = logging.FileHandler(path)
+        stream_handler = logging.StreamHandler(sys.stderr)
+        logging.basicConfig(level=logging.DEBUG, handlers=[file_handler, stream_handler])
+
+        logger = logging.getLogger(__name__)
+        try:
+            x = 52
+            assert x == 90
+        except AssertionError:
+            logger.exception("test failed")
+
+        for h in root.handlers:
+            h.flush()
+
+        with open(path) as f:
+            file_output = f.read()
+        terminal_output = terminal.getvalue()
+
+        # File output should NOT have ANSI codes
+        assert not ANSI_ESCAPE.search(file_output),             f"File output should not contain ANSI codes: {file_output[:100]}"
+        print("PASS: file output has no ANSI codes")
+
+        # stderr output SHOULD have ANSI codes
+        assert ANSI_ESCAPE.search(terminal_output),             f"Terminal output should contain ANSI codes: {terminal_output[:100]}"
+        print("PASS: terminal output has ANSI codes")
+    finally:
+        sys.stderr = original_stderr
+        for h in root.handlers[:]:
+            h.close()
+            root.removeHandler(h)
+        os.remove(path)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #87

## Summary
When exceptions are logged via Python's `logging` module, ANSI color escape codes appear as raw text in log files. This fix ensures:
- **stderr output**: keeps colored exceptions (terminal experience preserved)
- **File/other handlers**: exceptions are plain text without ANSI codes

## Implementation
Modified `better_exceptions/log.py` to patch logging handlers differently based on type:
- `StreamHandler` targeting `sys.stderr` → uses colored `format_exception`
- All other handlers (FileHandler, etc.) → uses `ExceptionFormatter(colored=False)`

## Changes
- `better_exceptions/log.py` — handler-aware color stripping
- `test/test_file_logging.py` — test verifying file output has no ANSI codes while stderr does

## Acceptance criteria
- [x] Logged exceptions to files do not contain ANSI color codes
- [x] Terminal stderr output still shows colored exceptions
- [x] Existing functionality preserved
- [x] Test included