### PR TITLE
Avoid colorized tracebacks in file logs

### DIFF
--- a/better_exceptions/log.py
+++ b/better_exceptions/log.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import
 
 import sys
 
-from logging import Logger, StreamHandler
+from copy import copy
+from logging import FileHandler, Logger, StreamHandler
 
 
 def patch():
@@ -11,14 +12,47 @@ def patch():
 
     logging_format_exception = lambda exc_info: u''.join(format_exception(*exc_info))
 
+    def patch_formatter(formatter):
+        if getattr(formatter, '_better_exceptions_patched', False):
+            return
+
+        original_format = formatter.format
+
+        def logging_format(record):
+            exc_text = record.exc_text
+            record.exc_text = None
+            try:
+                return original_format(record)
+            finally:
+                record.exc_text = exc_text
+
+        formatter.formatException = logging_format_exception
+        formatter.format = logging_format
+        formatter._better_exceptions_patched = True
+
     if hasattr(logging, '_defaultFormatter'):
         logging._defaultFormatter.format_exception = logging_format_exception
 
-    patchables = [handler() for handler in logging._handlerList if isinstance(handler(), StreamHandler)]
-    patchables = [handler for handler in patchables if handler.stream == sys.stderr]
-    patchables = [handler for handler in patchables if handler.formatter is not None]
-    for handler in patchables:
-        handler.formatter.formatException = logging_format_exception
+    for handler_ref in logging._handlerList:
+        handler = handler_ref()
+        if handler is None:
+            continue
+
+        if not isinstance(handler, StreamHandler) or isinstance(handler, FileHandler):
+            continue
+
+        if handler.stream != sys.stderr or handler.formatter is None:
+            continue
+
+        formatter = handler.formatter
+        for other_handler_ref in logging._handlerList:
+            other_handler = other_handler_ref()
+            if other_handler is not None and other_handler is not handler and other_handler.formatter is formatter:
+                formatter = copy(formatter)
+                handler.setFormatter(formatter)
+                break
+
+        patch_formatter(formatter)
 
 
 class BetExcLogger(Logger):

--- a/test/test_logging_file.py
+++ b/test/test_logging_file.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import
+
+import logging
+import os
+import tempfile
+
+import better_exceptions
+
+
+ANSI_ESCAPE = '\x1b['
+
+
+def explode():
+    marker = 'file logs should not be colorized'
+    raise RuntimeError(marker)
+
+
+def main():
+    path = os.path.join(tempfile.gettempdir(), 'better_exceptions_file_logging.log')
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
+    logger = logging.getLogger('better_exceptions.file_logging')
+    logger.handlers[:] = []
+    logger.propagate = False
+    logger.setLevel(logging.ERROR)
+
+    formatter = logging.Formatter('%(levelname)s:%(message)s')
+
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+
+    file_handler = logging.FileHandler(path, mode='w')
+    file_handler.setFormatter(formatter)
+
+    logger.addHandler(console_handler)
+    logger.addHandler(file_handler)
+
+    better_exceptions.hook()
+
+    try:
+        explode()
+    except RuntimeError:
+        logger.exception('shared formatter failure')
+
+    file_handler.close()
+
+    with open(path, 'r') as logfile:
+        logged = logfile.read()
+
+    assert ANSI_ESCAPE not in logged, logged
+
+
+if __name__ == '__main__':
+    main()

--- a/test/test_logging_file.py
+++ b/test/test_logging_file.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import
 
 import logging
 import os
+import sys
 import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import better_exceptions
 


### PR DESCRIPTION
Fixes #87.

This keeps better-exceptions' colored traceback formatting for stderr logging, but prevents that colored `exc_text` cache from leaking into file handlers when handlers share a formatter.

The regression covers a console `StreamHandler` and `FileHandler` sharing one `Formatter`: the console handler still gets the better-exceptions traceback, while the file log remains free of ANSI escape codes.

Validation:
- `python test\test_logging_file.py`
- `python -m py_compile better_exceptions\log.py test\test_logging_file.py`
- `python -m py_compile` over all repository Python files
- `git diff --check`

Note: I could not run `bash test_all.sh` in this Windows environment because WSL failed to mount its Ubuntu disk (`ERROR_FILE_NOT_FOUND`). The focused regression and compile checks passed locally.

IssueHunt: $50 funded on #87.